### PR TITLE
Add links to support page and RDHPCS home page

### DIFF
--- a/source/_static/js/custom.js
+++ b/source/_static/js/custom.js
@@ -1,0 +1,49 @@
+$(document).ready(function () {
+
+    // Create link and text for navigation back to the RDHPCS home page
+    var home_link = document.createElement("a");
+    var home_text = document.createTextNode("RDHPCS Home Page");
+    home_link.appendChild(home_text);
+    home_link.setAttribute("href", "https://www.noaa.gov/information-technology/hpcc");
+
+    // Open the RDHPCS home page in new tab when clicked
+    home_link.setAttribute("target", "_blank");
+
+    var separator = document.createTextNode(" | ");
+
+    // These items are right-aligned in the RTD theme breadcrumbs
+    aside = document.querySelector("body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside");
+
+    // Next to the default "Edit on GitHub", add a separator, then the RDHPCS link.
+    aside.appendChild(separator);
+    aside.appendChild(home_link);
+
+    // Insert "Help email" below html_logo in sidebar navigation
+    var help_link = document.createElement("a");
+    var help_link_text = document.createTextNode("Need Help? ");
+    var email_link_text = document.createTextNode(" Click Here.");
+    help_link.appendChild(help_link_text);
+    help_link.appendChild(email_link_text);
+    help_link.setAttribute("href", "/help/index.html");
+
+    wysidenavsearch = document.querySelector("body > div > nav > div > div.wy-side-nav-search > a");
+    wysidenavsearch.appendChild(help_link);
+
+    // For any external links in the main navigation, append the FontAwesome external link icon.
+    function iconize_external_links(nav_level) {
+        a_elements = nav_level.getElementsByTagName("A");
+        for (var i = 0; i < a_elements.length; ++i) {
+            if (a_elements[i].getAttribute("href").includes("http")) {
+                var icon = document.createElement("i");
+                icon.classList.add("fa");
+                icon.classList.add("fa-external-link");
+                var spacer = document.createTextNode(" ");
+                a_elements[i].appendChild(spacer);
+                a_elements[i].appendChild(icon);
+            }
+        }
+    }
+
+    iconize_external_links(document.querySelector("body > div > nav > div > div.wy-menu.wy-menu-vertical"))
+
+});

--- a/source/conf.py
+++ b/source/conf.py
@@ -8,51 +8,53 @@
 
 import datetime as dt
 
-project = 'NOAA RDHPCS User Documentation'
-copyright = '%s, National Oceanic and Atmospheric Administration' % dt.datetime.now().year
-author = 'NOAA RDHPCS'
-html_logo = 'images/NOAA_RDHPCS.png'
-html_favicon = 'images/favicon.ico'
+project = "NOAA RDHPCS User Documentation"
+copyright = (
+    "%s, National Oceanic and Atmospheric Administration" % dt.datetime.now().year
+)
+author = "NOAA RDHPCS"
+html_logo = "images/NOAA_RDHPCS.png"
+html_favicon = "images/favicon.ico"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = [
-    'sphinx_rtd_theme',
-    'sphinx_design',
-    'sphinxcontrib.mermaid'
-]
+extensions = ["sphinx_rtd_theme", "sphinx_design", "sphinxcontrib.mermaid"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_baseurl = 'https://docs.rdhpcs.noaa.gov'
+html_theme = "sphinx_rtd_theme"
+html_baseurl = "https://docs.rdhpcs.noaa.gov"
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-    'css/theme_overrides.css',
+    "css/theme_overrides.css",
+]
+
+html_js_files = [
+    "js/custom.js",
 ]
 
 html_context = {
-    'vcs_pageview_mode': 'edit',
-    'display_github': True,
-    'github_user': 'NOAA-RDHPCS',  # Username
-    'github_repo': 'noaa-rdhpcs.github.io',  # Repo name
-    'github_version': 'main',  # Version
-    'conf_py_path': '/source/',  # Path in the checkout to the docs root
+    "vcs_pageview_mode": "edit",
+    "display_github": True,
+    "github_user": "NOAA-RDHPCS",  # Username
+    "github_repo": "noaa-rdhpcs.github.io",  # Repo name
+    "github_version": "main",  # Version
+    "conf_py_path": "/source/",  # Path in the checkout to the docs root
 }
 
 # see https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 html_theme_options = {
-    'collapse_navigation': False,
-    'sticky_navigation': True,
-    'navigation_depth': 4,
-    'style_external_links': True,
-    'style_nav_header_background': '#efefef',
-    'logo_only': True,
+    "collapse_navigation": False,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "style_external_links": True,
+    "style_nav_header_background": "#efefef",
+    "logo_only": True,
 }


### PR DESCRIPTION
The updates add the items as shown in the image:

<img width="1047" alt="Screenshot 2024-01-23 at 6 48 31 PM" src="https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io/assets/432715/a275fc39-c143-44a9-aaa3-e9f007b558c8">

The "Need help? Click here." will take the user to the getting help/support page.  The "RDHPCS Home Page" will take the user to the [OCIO's HPCC page](https://www.noaa.gov/information-technology/hpcc).
