### PR TITLE
Deploy to not run on forks

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -29,7 +29,7 @@ jobs:
     # Only run deploy on push events.  This will also trigger after a PR is
     # approved.  Sincet push will only trigger to the main branch, this will
     # only deploy the main branch.
-    if: github.event_name == 'push'
+    if: ${{ github.event_name == 'push' && github.repository == 'noaa-rdhpcs/noaa-rdhpcs.github.io' }}
     needs: build
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment


### PR DESCRIPTION
This is to stop the deploy from attempting in forks, as additional items are needed for the deploy to succeed in a fork.

fixes #55 