### PR TITLE
globus example updated

### DIFF
--- a/source/data/globus_online_data_transfer.rst
+++ b/source/data/globus_online_data_transfer.rst
@@ -100,7 +100,8 @@ Globus Connect Service is available on the following RDHPCS and partner clusters
 
 
   .. tab-item:: Hercules
-:sync: hercules
+   :sync: hercules
+
 
    +-----------+---------------------+--------------------+----------------------+---------------+
    | Cluster   | Display Name        | File Systems       | Site                 | Access        | 
@@ -171,5 +172,6 @@ Some benefits of using Globus Connect Personal with UDTNs:
 * Data transfers automatically suspends and resumes as your computer goes to sleep, wakes up, or reboots.
 * The mechanism for transferring data between your laptop/workstation (Untrusted Endpoint) and a NOAA RDHPCS UDTN is exactly the same.
 
-Please see `Globus Connect Personal <https://www.globus.org/globus-connect-personal>`_ for information about setting up your laptop/workstation as a Globus Personal Endpoint.
+See `Globus Connect Personal documentation 
+<https://www.globus.org/globus-connect-personal>`_ for information about setting up your laptop/workstation as a Globus Personal Endpoint.
 

--- a/source/systems/jet_user_guide.rst
+++ b/source/systems/jet_user_guide.rst
@@ -42,11 +42,11 @@ partitions, plus four bigmem nodes, totaling 57,744 coes, @
 | Interconnect  | QDR        | QDR        | QDR        | FDR      | FDR        | FDR        | EDR        |
 |               | Infiniband | Infiniband | Infiniband |Infiniband| Infiniband | Infiniband | Infiniband |
 +---------------+------------+------------+------------+----------+------------+------------+------------+
-| Total Flops\* | 96.8 TF    | 30.4 TF    | 113.2 TF   | 93.6 TF  | 717.4 TF   | 3.5 TF     | 827 TF     |
+| Total Flops   | 96.8 TF    | 30.4 TF    | 113.2 TF   | 93.6 TF  | 717.4 TF   | 3.5 TF     | 827 TF     |
 +---------------+------------+------------+------------+----------+------------+------------+------------+
 
 
-Notes:
+**Notes:**
 
 -  Jet's Front Ends (service partition) have the same architecture as the xJet compute nodes.
 -  Total flops is a theoretical peak and does not represent actual performance.


### PR DESCRIPTION
added the text from the Draft Transfer Document to the Globus information -- I'm open to the idea that it be in a separate chapter, but wanted to get the information into the new format.