### PR TITLE
Add required items for Google to index the site

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
 sphinx_design
+sphinx-sitemap
 sphinxcontrib-mermaid
 doc8

--- a/source/_search/google64634d0922861b1a.html
+++ b/source/_search/google64634d0922861b1a.html
@@ -1,0 +1,1 @@
+google-site-verification: google64634d0922861b1a.html

--- a/source/_search/robots.txt
+++ b/source/_search/robots.txt
@@ -1,0 +1,6 @@
+# Only index the actual documentation:
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.rdhpcs.noaa.gov/sitemap.xml
+

--- a/source/conf.py
+++ b/source/conf.py
@@ -19,7 +19,10 @@ html_favicon = "images/favicon.ico"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx_rtd_theme", "sphinx_design", "sphinxcontrib.mermaid"]
+extensions = ["sphinx_rtd_theme",
+              "sphinx_design",
+              "sphinxcontrib.mermaid",
+              "sphinx_sitemap"]
 
 templates_path = ["_templates"]
 exclude_patterns = []
@@ -31,6 +34,9 @@ html_theme = "sphinx_rtd_theme"
 html_baseurl = "https://docs.rdhpcs.noaa.gov"
 
 html_static_path = ["_static"]
+
+html_extra_path = ["_search/google64634d0922861b1a.html",
+                   "_search/robots.txt"]
 
 html_css_files = [
     "css/theme_overrides.css",


### PR DESCRIPTION
Google needs the google*.html file to index the site.  The build process will also create a sitemap file in a location that is defined in the robots.txt file.

This needs to be merged before #86 so we know Google is indexing the site.
