### PR TITLE
Remove the localization from the sitemap URL paths

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -31,7 +31,7 @@ exclude_patterns = []
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_baseurl = "https://docs.rdhpcs.noaa.gov"
+html_baseurl = "https://docs.rdhpcs.noaa.gov/"
 
 html_static_path = ["_static"]
 
@@ -84,3 +84,12 @@ linkcheck_ignore = [
 # several links that point to pages that require a user
 # to authenticate.  This ensures the links pass the check.
 linkcheck_allow_unauthorized = True
+
+# Additional sitemap settings
+# https://sphinx-sitemap.readthedocs.io/en/latest/index.html
+sitemap_url_scheme = "{link}"
+sitemap_locales = [None]
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+]


### PR DESCRIPTION
This adds additional sphinx_sitemap configurations to source/conf.py to avoid including the localization information in the URL path.