### PR TITLE
update "Contributing via CLI"

### DIFF
--- a/source/contributing/via_cli/index.rst
+++ b/source/contributing/via_cli/index.rst
@@ -11,13 +11,6 @@ your system.
 Setup authoring environment
 ==============================
 
-#. Install Sphinx and the ReadTheDocs theme locally::
-
-        $ pip3 install sphinx sphinx_rtd_theme sphinx-panels
-
-   This can be in your home area, a virtual environment, container, etc.
-
-
 #. Fork the documentation repository on GitHub
 
     Go to https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io, and click the "Fork"
@@ -38,6 +31,16 @@ Setup authoring environment
     $ git remote add rdhpcs https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io.git
     $ git fetch rdhpcs
     $ git branch --set-upstream-to=rdhpcs/main
+
+#. Install Sphinx and the ReadTheDocs theme locally::
+
+        $ pip3 install -r requirements.txt
+
+   This can be in your home area, a virtual environment, container, etc.
+
+    Go to https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io/blob/main/requirements.txt
+    to see the list of Python packages inside ``requirements.txt``.
+
 
 #. Build the docs::
 


### PR DESCRIPTION
spoke with @underwoo about the following:
- the "Contributing via CLI" article referred to a list of Python packages, not the "requirements.txt" file
- @underwoo mentioned it would be better to have the `pip3 install` command reference the file
    - this allows the team to add packages to the file, without having to remember to update the article
- the instructions were also moved to a later point in the article
    - now, the user will have already "changed directory" into the cloned repo, and the path to "requirements.txt" will be correct
- also, added a GitHub link to the "requirements.txt" file, so any user can see what packages will be installed, even before cloning the repo