### PR TITLE
Build/host documentation on readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "source/" directory with Sphinx
+sphinx:
+  configuration: source/conf.py
+
+# Declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: requirements.txt
+

--- a/source/_templates/search.html
+++ b/source/_templates/search.html
@@ -13,7 +13,7 @@
 
 {%- block scripts %}
     {{ super() }}
-    {%- if gsce_id %}
+    {%- if not READTHEDOCS and gsce_id %}
       <script async src="https://cse.google.com/cse.js?cx={{ gsce_id }}"></script>
     {%- else %}
       <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
@@ -46,7 +46,7 @@
       <p>{{ _('Your search did not match any documents. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.') }}</p>
     {% endif %}
   {% endif %}
-  {%- if gsce_id %}
+  {%- if not READTHEDOCS and gsce_id %}
     <div class="gcse-searchresults-only">
   {%- else %}
     <div id="search-results">


### PR DESCRIPTION
Once in place, this can be used to:

* Show PR builds
* Compare RTD search to Google search