### PR TITLE
updated the "Jupyter on RDHPCS" guide

### DIFF
--- a/source/software/python/jupyter.rst
+++ b/source/software/python/jupyter.rst
@@ -144,7 +144,7 @@ local port number:
 
 .. code-block:: shell
 
-    $ ssh -L 12345:localhost:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
+    $ ssh -L 12345:127.0.0.1:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
 
 Once logged in, start the JupyterLab session using a port number in the range
 8800-8900 range:
@@ -171,8 +171,15 @@ Once logged in, start the JupyterLab session using a port number in the range
 
     Take note of the URL provided to you by Jupyter for a later step.  It will
     resemble
-    ``http://localhost:<port#>/lab?token=################################################``.
+    ``http://127.0.0.1:<port#>/lab?token=################################################``.
     You will need the full token number.
+
+.. warning::
+
+    Be aware that the port number assigned by Jupyter may be different
+    than the one specified. This can occur when the chosen port is already
+    in use. In this case, Jupyter will assign the next available port.
+    If the port number changes, make note of it for the next command.
 
 window 2
 """"""""
@@ -182,7 +189,7 @@ JupyterLab session between your localhost and the RDHPCS system:
 
 .. code-block:: shell
 
-    $ ssh -N -f -p 12345 -L <port#>:localhost:<port#> J.Doe@localhost
+    $ ssh -p 12345 -L <port#>:127.0.0.1:<port#> J.Doe@127.0.0.1
 
 .. note::
 
@@ -202,7 +209,7 @@ local port number:
 
 .. code-block:: shell
 
-    $ ssh -L 12345:localhost:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
+    $ ssh -L 12345:127.0.0.1:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
 
 Start an interactive batch session.  On the compute node, use ``hostname`` to
 get the name of the compute node.  This will be needed later:
@@ -239,8 +246,15 @@ Start the JupyterLab session using a port number in the range 8800-8900 range:
 
     Take note of the URL provided to you by Jupyter for a later step.  It will
     resemble
-    ``http://localhost:<port#>/lab?token=################################################``.
+    ``http://127.0.0.1:<port#>/lab?token=################################################``.
     You will need the full token number.
+
+.. warning::
+
+    Be aware that the port number assigned by Jupyter may be different
+    than the one specified. This can occur when the chosen port is already
+    in use. In this case, Jupyter will assign the next available port.
+    If the port number changes, make note of it for the next two commands.
 
 window 2
 """"""""
@@ -250,14 +264,14 @@ JupyterLab session between your localhost and the RDHPCS system:
 
 .. code-block:: shell
 
-    $ ssh -p 12345 -L <port#>:localhost:<port#> J.Doe@localhost
+    $ ssh -p 12345 -L <port#>:127.0.0.1:<port#> J.Doe@127.0.0.1
 
 Once the connection is established, using the compute node host name establish
 a connection to the compute node with tunnels to the JupyterLab session port:
 
 .. code-block:: shell
 
-    $ ssh -f -N -L <port#>:localhost:<port#> <cn_hostname>
+    $ ssh -L <port#>:127.0.0.1:<port#> <cn_hostname>
 
 .. note::
 


### PR DESCRIPTION
This commit addresses some concerns that were discovered while working with a user.

First, it was noted that Jupyter Lab can assign the user a different port than the one specified. This occurs if the user gives Jupyter a port that is already occupied. In this case, Jupyter increments the port until it finds an available port. Then, if the user is unaware of the port change, the second SSH tunnel command will fail.

Second, the user continued to experience issues when tunnelling, which were successfully addressed by specifying the IPv4 loopback address of `127.0.0.1`, instead of using `localhost`. When using `localhost`, the system's host file can choose to resolve the hostname by using the IPv6 loopback address (`::1`). For some users, the IPv6 address will cause attempted connections to fail. This commit proposes that the Jupyter guide instructs users to hardcode the IPv4 loopback in order to avoid these connection issues.

---

changes in this commit include:

- added warning that Jupyter may change ports, if the specified port is already in use
- changed `localhost` to `127.0.0.1` in `ssh` commands for Jupyter