### PR TITLE
Include the URL for AIM

### DIFF
--- a/source/FAQ/index.rst
+++ b/source/FAQ/index.rst
@@ -286,7 +286,7 @@ How do I change my default login shell?
 
 To change your default shell:
 
-* Log into AIM https://aim.rdhpcs.noaa.gov/
+* Log into `AIM  <https://aim.rdhpcs.noaa.gov/>`_.
 * Click "view your information in AIM".
 * Navigate down to the "Projects and Account Information" section.
 * Click the dropdown menu (middle panel) next to "Shell selection".

--- a/source/FAQ/index.rst
+++ b/source/FAQ/index.rst
@@ -286,7 +286,7 @@ How do I change my default login shell?
 
 To change your default shell:
 
-* Log into AIM.
+* Log into AIM https://aim.rdhpcs.noaa.gov/
 * Click "view your information in AIM".
 * Navigate down to the "Projects and Account Information" section.
 * Click the dropdown menu (middle panel) next to "Shell selection".


### PR DESCRIPTION
The instructions tell the user to go to AIM but doesn't include the URL.  This change is to include the URL so that users can navigate to the site.

Reference: OTRS: https://helpdesk.rdhpcs.noaa.gov/otrs/index.pl?Action=AgentTicketZoom;TicketID=54160#515186