### PR TITLE
added the Ursa help desk e-mail to the e-mail table

### DIFF
--- a/source/help/index.rst
+++ b/source/help/index.rst
@@ -30,6 +30,8 @@ When sending an e-mail, be sure to do the following:
 +------------------+------------------------------+
 | Niagara          | rdhpcs.niagara.help@noaa.gov |
 +------------------+------------------------------+
+| Ursa             | rdhpcs.ursa.help@noaa.gov    |
++------------------+------------------------------+
 | Orion            | rdhpcs.orion.help@noaa.gov   |
 +------------------+------------------------------+
 | Hercules         | rdhpcs.hercules.help@noaa.gov|


### PR DESCRIPTION
As the commit title states, this was a simple addition to the help desk e-mail table to include an e-mail address for the new Ursa HPC system.

This was a request by Forrest.