### PR TITLE
Change the CAC bastion DNS names for Ursa/Mercury to have "-cac"

### DIFF
--- a/source/connecting/index.rst
+++ b/source/connecting/index.rst
@@ -106,13 +106,13 @@ Bastion Hostnames
 .. |PAPRNG|	replace:: analysis-rsa.princeton.rdhpcs.noaa.gov
 .. |PBPRNG|	replace:: analysis-rsa.boulder.rdhpcs.noaa.gov
 
-.. |MCPRNG|	replace:: mercury.princeton.rdhpcs.noaa.gov
-.. |MCBRNG|	replace:: mercury.boulder.rdhpcs.noaa.gov
+.. |MCPRNG|	replace:: mercury-cac.princeton.rdhpcs.noaa.gov
+.. |MCBRNG|	replace:: mercury-cac.boulder.rdhpcs.noaa.gov
 .. |MRPRNG|	replace:: mercury-rsa.princeton.rdhpcs.noaa.gov
 .. |MRBRNG|	replace:: mercury-rsa.boulder.rdhpcs.noaa.gov
 
-.. |UCPRNG|	replace:: ursa.princeton.rdhpcs.noaa.gov
-.. |UCBRNG|	replace:: ursa.boulder.rdhpcs.noaa.gov
+.. |UCPRNG|	replace:: ursa-cac.princeton.rdhpcs.noaa.gov
+.. |UCBRNG|	replace:: ursa-cac.boulder.rdhpcs.noaa.gov
 .. |URPRNG|	replace:: ursa-rsa.princeton.rdhpcs.noaa.gov
 .. |URBRNG|	replace:: ursa-rsa.boulder.rdhpcs.noaa.gov
 


### PR DESCRIPTION
Issue#428