### PR TITLE
accounts_and_projects.rst: replace or update informational graphic

### DIFF
--- a/source/accounts/accounts_and_projects.rst
+++ b/source/accounts/accounts_and_projects.rst
@@ -6,8 +6,6 @@ about getting to work. In general, NOAA RDHPCS resources are granted
 to projects in allocations on systems, and are made available to the
 users associated with each project.
 
-.. image:: /images/RDHPCS_AIM_relationship_graphic.png
-
 .. _applying_for_user_account:
 
 Applying for a user account


### PR DESCRIPTION
Delete graphic - it takes up too much screen real estate and will constantly have to be updated as systems come online.