### PR TITLE
Update Gaea UG - remove intel-classic and intel-oneapi module references

### DIFF
--- a/.vscode/dicts/projWords.txt
+++ b/.vscode/dicts/projWords.txt
@@ -104,7 +104,6 @@ genv
 genvall
 genvlist
 getstripe
-GFPS
 gitflow
 Globus
 globusconnectpersonal
@@ -181,7 +180,6 @@ libcoolkeypk
 libmpi
 libsci
 Linaro
-linenos
 LINTRST
 llapack
 lmgfdl

--- a/.vscode/dicts/projWords.txt
+++ b/.vscode/dicts/projWords.txt
@@ -47,6 +47,7 @@ cowsay
 CPATH
 cpio
 cpuid
+cpus
 CRAN
 craype
 creds
@@ -106,6 +107,7 @@ genv
 genvall
 genvlist
 getstripe
+GFPS
 gitflow
 Globus
 globusconnectpersonal
@@ -182,6 +184,7 @@ libcoolkeypk
 libmpi
 libsci
 Linaro
+linenos
 LINTRST
 llapack
 lmgfdl
@@ -210,6 +213,7 @@ memberwork
 mgmt
 Minfo
 MKLROOT
+mmchattr
 Moba
 modulefamilies
 modulefil
@@ -227,8 +231,10 @@ MPMD
 MRBRNG
 MRPRNG
 Msafeptr
+msgq
 msstate
 MSUHPC
+multifactor
 mvapich
 myccode
 mycexe
@@ -243,6 +249,7 @@ NCAR
 NCARG
 NCBRNG
 nccmp
+NCCS
 NCEP
 NCEPLIBS
 NCPRNG
@@ -279,6 +286,7 @@ opari
 openmp
 openmpi
 opensc
+ORNL
 ortar
 OTRS
 otrsnewticket
@@ -349,6 +357,7 @@ silene
 simg
 sjet
 Skylake
+SLES
 slurmctld
 slurmd
 slurmdbd

--- a/source/systems/gaea_user_guide.rst
+++ b/source/systems/gaea_user_guide.rst
@@ -467,7 +467,7 @@ The following is the current policy for compression on F5:
    /* Ensure compression on qualified files */
    RULE 'compress-large-files-on-hdd' MIGRATE COMPRESS('lz4') FROM POOL 'capacity' WHERE not(excluded_files) AND (KB_ALLOCATED >= 4096) AND access_buffer_time_passed
 
-**Additional notes regarding GFPS compression:**
+**Additional notes regarding GPFS compression:**
 
 * Users can decompress their files by running
   ``mmchattr --compression no -I yes <file>``.

--- a/source/systems/gaea_user_guide.rst
+++ b/source/systems/gaea_user_guide.rst
@@ -634,8 +634,7 @@ table below lists details about each of the module-provided compilers.
 .. |pe_gnu| replace:: ``PrgEnv-gnu``
 .. |pe_intel| replace:: ``PrgEnv-intel``
 .. |pe_nvhpc| replace:: ``PrgEnv-nvhpc``
-.. |intel_cl| replace:: ``intel-classic``
-.. |intel_oa| replace:: ``intel-oneapi``
+
 
 +--------+-------------+----------------+----------+----------+---------------+
 | Vendor | Programming | Compiler       | Language | Compiler | Compiler      |
@@ -666,18 +665,6 @@ table below lists details about each of the module-provided compilers.
 |        |             |                | C++      | ``CC``   | ``icpx``      |
 |        |             |                +----------+----------+---------------+
 |        |             |                | Fortran  | ``ftn``  | ``ifort``     |
-|        |             +----------------+----------+----------+---------------+
-|        |             | |intel_cl|     | C        | ``cc``   | ``icc``       |
-|        |             |                +----------+----------+---------------+
-|        |             |                | C++      | ``CC``   | ``icpc``      |
-|        |             |                +----------+----------+---------------+
-|        |             |                | Fortran  | ``ftn``  | ``ifort``     |
-|        |             +----------------+----------+----------+---------------+
-|        |             | |intel_oa|     | C        | ``cc``   | ``icx``       |
-|        |             |                +----------+----------+---------------+
-|        |             |                | C++      | ``CC``   | ``icpx``      |
-|        |             |                +----------+----------+---------------+
-|        |             |                | Fortran  | ``ftn``  | ``ifx``       |
 +--------+-------------+----------------+----------+----------+---------------+
 | NVIDIA | |pe_nvhpc|  | ``nvhpc``      | C        | ``cc``   | ``nvc``       |
 |        |             |                +----------+----------+---------------+


### PR DESCRIPTION
Fixes #422 
Removed references to intel-classic and intel-oneapi 