### PR TITLE
added a link to QOS table

### DIFF
--- a/.vscode/dicts/projWords.txt
+++ b/.vscode/dicts/projWords.txt
@@ -3,9 +3,12 @@ ACORS
 ALLINEA
 ALLNODES
 antlr
+aoml
 Apptainer
 archrpt
 aval
+avgdata
+avgtext
 awscli
 awscliv
 awsnoaa
@@ -26,10 +29,12 @@ bucketname
 byacc
 cactest
 CBHN
+ccasm
 CCODE
 CFLAGS
 cgateway
 checkjob
+chgrp
 chicklet
 clib
 cloudmgmt
@@ -63,6 +68,8 @@ devcimultiintel
 devel
 DFTI
 Diskspace
+dispositioned
+dispositioning
 dmget
 dmlocate
 dmls
@@ -115,6 +122,7 @@ GPUDIRECT
 gpuwf
 GRBRNG
 Gres
+grib
 groupinstall
 groupname
 GRPRNG
@@ -126,6 +134,7 @@ guilabel
 gvimdiff
 GVNIC
 habanero
+hafs
 Haswell
 HCBRNG
 HCPRNG
@@ -160,6 +169,9 @@ itac
 JCBRNG
 JCPRNG
 jetmgmt
+joberr
+jobfile
+jobout
 JRBRNG
 JRPRNG
 Jumpstart
@@ -180,6 +192,7 @@ libcoolkeypk
 libmpi
 libsci
 Linaro
+linenos
 LINTRST
 llapack
 lmgfdl
@@ -200,6 +213,7 @@ Makefiles
 mambaenv
 MANPATH
 Mathematica
+maxresident
 MCBRNG
 MCPRNG
 mdlcloud
@@ -212,6 +226,7 @@ mmchattr
 Moba
 modulefamilies
 modulefil
+MODULESHOME
 mpicc
 mpicpp
 mpiexec
@@ -237,8 +252,10 @@ myexe
 myfort
 myfortcode
 myfxex
+myjob
 myprog
 Myrinet
+myrun
 nbhome
 NCAR
 NCARG
@@ -265,6 +282,7 @@ nodocs
 nofma
 nompi
 NOPASSWD
+Normshares
 noslurm
 nranks
 NRBRNG
@@ -284,6 +302,7 @@ openmpi
 opensc
 ORNL
 ortar
+osse
 OTRS
 otrsnewticket
 otrsopentickettab
@@ -300,6 +319,7 @@ pcluster
 perftools
 peta
 petaflops
+phod
 physcpubind
 pkcs
 podaac
@@ -308,6 +328,8 @@ PPPRNG
 prarms
 Preconfigured
 procname
+projid
+PROJWORK
 psurge
 ptmp
 pubkeys
@@ -338,6 +360,7 @@ rstprod
 rtfim
 rtnim
 runscript
+sacccount
 Sandybridge
 Scalapack
 Secur
@@ -366,6 +389,7 @@ squashfs
 sshg
 SSLVPN
 stacksize
+Stmp
 suspendtime
 szip
 tcpip
@@ -403,10 +427,12 @@ UTDN
 valgrind
 Vampir
 VARNAME
+verif
 vftmp
 vimdiff
 vjet
 vtune
+wallclock
 WCOSS
 wgrib
 wmem

--- a/source/queue_policy/policies.rst
+++ b/source/queue_policy/policies.rst
@@ -509,7 +509,7 @@ Niagara:
   have not been accessed in the last 60 days will be automatically
   purged.
 * All files under the ``/collab1/data/$PROJECT`` directory are treated
-  the same as HPFS (scracth) data and are not deleted.
+  the same as HPFS (scratch) data and are not deleted.
 
 The definition of access time is the last time the file was opened for
 reading or writing.
@@ -582,7 +582,7 @@ Maintainers are expected to:
 * Follow the naming conventions and guidelines outlined in this
   document
 * Apply security updates as quickly as possible after they become
-  availble
+  available
 * Update software for bug fixes and functionality as users request
 * Respond to user email requests for help using the software
 
@@ -659,7 +659,7 @@ When installing software into your ``/contrib`` directory, first determine
 if this is software that should be versioned (multiple versions may
 exist at one time) or unversioned (there will only ever be one version
 installed, and upgrade will overwrite the existing software). For
-verisoned software, please install it into a subdirectory of your
+versioned software, please install it into a subdirectory of your
 package that is named after the version number. For supporting
 multiple versions of software the install path should be:
 
@@ -767,6 +767,8 @@ you run it.
 
    Do not use a time less than 120 seconds (2 min).
 
+.. _QOS-table:
+
 Jet and Hera
 ------------
 
@@ -808,8 +810,8 @@ Jet and Hera
      -  QOS for a job that requires more urgency than *batch*. Your
         project's :ref:`FairShare <slurm-fairshare>` will be lowered
         at 2.0x the rate as compared to *batch*.  Only one job per
-        project/account can be pending/runnin at any time. When a
-        project's FairShare is below 0.45, jobs submmit to *urgent*
+        project/account can be pending/running at any time. When a
+        project's FairShare is below 0.45, jobs submit to *urgent*
         are automatically changed to *batch* and users notified via
         stderr.
    * - debug

--- a/source/slurm/overview.rst
+++ b/source/slurm/overview.rst
@@ -406,10 +406,10 @@ specify these parameters, your job will be submitted to the default partition
 and QOS.
 
 If you wish choose a different partition or QOS you will need to specify them
-as per the table above. Different partitions and QOS are available, depending
-the resources you need. For example, jobs that require external network
-connectivity or HPSS access will generally need to be submited to the
-**service** partition.
+as per :ref:`the QOS table <QOS-table>`. Different partitions and QOS are
+available, depending the resources you need. For example, jobs that require
+external network connectivity or HPSS access will generally need to be
+submitted to the **service** partition.
 
 QOS is used to specify a **priority** for the job.
 


### PR DESCRIPTION
Fixes Issue #450 

The "Specifying Partitions and QOS" section of the Slurm overview refers to "the table above", but the table itself is missing.  The table in question appears in the Changing QOS’s section of the Policies and Best Practices chapter.

I created a link to the QOS table in the Changing QOS section.