### PR TITLE
adding a link to further Globus information

### DIFF
--- a/source/data/transferring_data.rst
+++ b/source/data/transferring_data.rst
@@ -78,6 +78,8 @@ authentication uses your RSA token.
 +----------+--------------------------------------+
 
 
+See the :ref:`globus_collection_summary` for complete information.
+
 Untrusted Data Transfer Nodes (UDTN)
 ====================================
 


### PR DESCRIPTION
Trusted DTN table is correct but users could need more information. Link to the comprehensive Collection table will get them there.