### PR TITLE
Fix a possible auto-correct error on the gres parameter

### DIFF
--- a/source/systems/ursa_user_guide.rst
+++ b/source/systems/ursa_user_guide.rst
@@ -170,7 +170,7 @@ the example below where 2 H100 GPUs on 1 node are being requested:
 
 .. code-block:: shell
 
-   sbatch -A mygpu_project -p u1-h100 -q gpu -N 1 –gres=gpu:h100:2 my_ml.job
+   sbatch -A mygpu_project -p u1-h100 -q gpu -N 1 –-gres=gpu:h100:2 my_ml.job
 
 Using GPU Resources Without a GPU allocation
 --------------------------------------------
@@ -190,7 +190,7 @@ being requested:
 
 .. code-block:: shell
 
-   sbatch -A mycpu_project -p u1-h100 -q gpuwf -N 1 –gres=gpu:h100:2 my_ml.job
+   sbatch -A mycpu_project -p u1-h100 -q gpuwf -N 1 –-gres=gpu:h100:2 my_ml.job
 
 
 Ursa Software Stack


### PR DESCRIPTION
The auto correct probably replaced ``--`` with a ``-``, that change has been reversed to fix this issue.