### PR TITLE
Remove CSS that disabled the logo anchor tag

### DIFF
--- a/source/_static/css/theme_overrides.css
+++ b/source/_static/css/theme_overrides.css
@@ -3,13 +3,6 @@
     max-width: 1200px;
 }
 
-/* Clicking on the NOAA RDHPCS logo does nothing
-   (disable RTD theme's default <a> behavior) */
-body>div>nav>div>div.wy-side-nav-search>a {
-    pointer-events: none;
-    cursor: default;
-}
-
 /* Don't let the color of the Docs Help link change. */
 a.a-nochange, a.a-nochange:visited {
     color: grey !important;


### PR DESCRIPTION
This makes the logo link clickable to the main landing page.

Fixes #517 