### PR TITLE
Change the sidebar to remove "NOAA RDHPCS" from the "systems" tab

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -46,7 +46,7 @@ Systems
 .. toctree::
    :maxdepth: 2
 
-   systems/index
+   Systems <systems/index>
 
 Data Storage and Transfers
 ==========================


### PR DESCRIPTION
Keep the extra text in `system/index.rst`, but only print "systems" in the sidebar.

Fixes #519 