### PR TITLE
removed MSU and Cloud from the Bastion table

### DIFF
--- a/.vscode/dicts/projWords.txt
+++ b/.vscode/dicts/projWords.txt
@@ -18,6 +18,7 @@ awsnoaa
 awsv
 azcopy
 azurestream
+baseprojectname
 bbcp
 bigdir
 bigmem
@@ -40,6 +41,7 @@ ccwrf
 CFLAGS
 cfsstrat
 cgateway
+chdir
 checkjob
 chgrp
 chicklet
@@ -54,6 +56,7 @@ CMRS
 cnvgrib
 codegen
 collab
+Collaboratory
 computecanada
 Coolkey
 coredumpsize
@@ -224,10 +227,12 @@ itac
 JCBRNG
 JCPRNG
 jcsda
+jdoe
 jetmgmt
 joberr
 jobfile
 jobout
+jobscript
 JRBRNG
 JRPRNG
 Jumpstart
@@ -283,8 +288,8 @@ mcwi
 mdlcloud
 Mellanox
 memberwork
-meso
 merc
+meso
 mgmt
 Minfo
 MKLROOT
@@ -330,7 +335,9 @@ mypartition
 myprog
 Myrinet
 myrun
+myscript
 NAGAPE
+namelist
 naqfc
 nbhome
 NCAR
@@ -344,6 +351,7 @@ NCEPLIBS
 NCEPPROD
 NCPRNG
 ncview
+ndays
 neaqs
 nedit
 nems
@@ -355,6 +363,8 @@ ngrr
 noaagfdl
 noaardhpcs
 noaastore
+noaatest
+noaatools
 NOATIME
 NODEFILE
 NODELIST
@@ -410,6 +420,7 @@ petaflops
 phod
 physcpubind
 pkcs
+PNETCDF
 podaac
 PPBRNG
 ppef
@@ -418,6 +429,7 @@ prarms
 Preconfigured
 procname
 profosse
+PROJECTNAME
 projid
 PROJWORK
 psurge
@@ -466,6 +478,8 @@ sacccount
 sair
 Sandybridge
 Scalapack
+SCHEDNODES
+Schnepp
 seaglider
 Secur
 securid
@@ -545,12 +559,14 @@ verif
 vftmp
 vimdiff
 vjet
+VSIZE
 vtune
 wallclock
 wamgip
 wamipe
 WCOSS
 wdas
+webform
 wgrib
 wmem
 wrfsatda
@@ -569,3 +585,4 @@ XTHI
 xtmp
 xxdiff
 xzvf
+zrtrr

--- a/source/connecting/index.rst
+++ b/source/connecting/index.rst
@@ -64,7 +64,7 @@ See MSU-HPC :ref:`MSUHPC-logging-in` for instructions.
 
 SSH clients are available for Windows-based systems, such as published
 by VanDyke software.  For recent SecureCRT versions, the preferred
-authentication setting shown above
+authentication setting is shown above.
 
 For Windows systems, `PuTTY
 <https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html>`_,
@@ -72,8 +72,8 @@ For Windows systems, `PuTTY
 `MobaXterm <https://mobaxterm.mobatek.net/>`_ can also be used to
 provide SSH capability.  Recent updates to Windows 10 and Windows 11
 have added built-in support for SSH.  If it is not installed on your
-version of Windows, please refer to Microsoft’s documentation on
-OpenSSH.
+version of Windows, please refer to Microsoft’s `documentation on
+OpenSSH <https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-server-2025>`_.
 
 .. _bastion_hostnames:
 
@@ -132,10 +132,6 @@ Bastion Hostnames
 |                   |                 |                                  |
 |                   | |PPBRNG|        | |PBPRNG|                         |
 +-------------------+-----------------+----------------------------------+
-| Cloud             | Unavailable     | https://noaa.parallel.works/sso  |
-+-------------------+-----------------+----------------------------------+
-| MSU-HPC Orion     | Unavailable     | |OUG|                            |
-+-------------------+-----------------+----------------------------------+
 | Mercury           | |MCBRNG|        | |MRBRNG|                         |
 |                   |                 |                                  |
 |                   | |MCPRNG|        | |MRPRNG|                         |
@@ -144,6 +140,17 @@ Bastion Hostnames
 |                   |                 |                                  |
 |                   | |UCPRNG|        | |URPRNG|                         |
 +-------------------+-----------------+----------------------------------+
+
+In addition to the Bastions, RDHPCS users have access to computational capacity
+on the Orion and Hercules systems, hosted by Mississippi State University. See
+the :ref:`MSU-HPC <MSU-HPC-user-guide>` user guide.
+for detailed information.
+
+Computational capacity is also available on the RDHPCS Cloud Platform, which
+allows NOAA users to create custom HPC clusters on an as-needed basis, through
+the Parallel Works platform. The :ref:`Cloud User Guide <cloud-user-guide>`
+provides more information.
+
 
 .. _Common-access:
 .. _cac_instructions:

--- a/source/systems/MSU-HPC_user_guide.rst
+++ b/source/systems/MSU-HPC_user_guide.rst
@@ -766,8 +766,8 @@ There are several different QOS'es depending on your needs.
      -  QOS for a job that requires more urgency than *batch*. Your
         project :ref:`FairShare <slurm-fairshare>` will be lowered at
         2.0x the rate as compared to *batch*.  Only one job pe
-        project/account can be pending/runnin at any time. When a
-        project's FairShare is below 0.45, jobs submmit to *urgent*
+        project/account can be pending/running at any time. When a
+        project's FairShare is below 0.45, jobs submit to *urgent*
         are automatically changed to *batch* and users notified via
         stderr.
    * - debug
@@ -1065,7 +1065,7 @@ priority.
 **Load contrib and noaatools Module**
 
 The module tools work on all MSU-HPC systems. On the MSU-HPC side,
-load the noaatools modu:: shell
+load the noaatools module shell
 
    $ module avail
    $ module load contrib noaatools
@@ -1443,7 +1443,7 @@ Before you begin, collect the following details:
 
 -  First Name
 -  Last Name
--  Desired Login Name - Typcially first initial, last name
+-  Desired Login Name - Typically first initial, last name
    (John Doe = jdoe)
 -  Email address. Preferably the user's @noaa.gov address. Otherwise
    use a business email address that best aligns with the user's work
@@ -1478,7 +1478,7 @@ Before you begin, collect the following details:
 Once the initial account request has been submitted, MSU will send the
 prospective user email similar to the following, to request the
 additional information needed for the background check and account
-finalizatize:
+finalization:
 
 .. code-block:: shell
 


### PR DESCRIPTION
The Bastions table contains references to Cloud and MSU HPC systems, which aren't bastions as such, nor accessed by the same means.

So they're removed from the table, with references below to the appropriate system guides.