### PR TITLE
Add information for Gaea to indicate the python modules do not include conda

### DIFF
--- a/source/software/index.rst
+++ b/source/software/index.rst
@@ -8,7 +8,7 @@ Software
    :maxdepth: 2
 
    modules/index
-   python/index
+   Python <python/index>
    workflows/index
    debuggers/index
    compilers/index

--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -53,8 +53,8 @@ If you want to leverage Python with Jupyter, we direct you to our
 
     The RDHPCS is diligently working to implement a unified Python/Conda
     configuration and policies across all NOAA-managed RDHPCS systems (Hera,
-    Jet, Mercury, Pan). Rest assured, this documentation will be updated as
-    these configurations and policies are implemented.
+    Jet, Mercury, Pan). This documentation will be updated as these
+    configurations and policies are implemented.
 
 .. _python-guides:
 
@@ -109,6 +109,14 @@ To start using Python, load the ``python`` module.
 
             $ module use /usw/conda/modulefiles
             $ module load python
+
+        .. note::
+
+            While the path to the Python module on Gaea is in a directory path
+            with the name of ``conda``, the Python module will not initialize
+            the Conda environment.  If you want to use Conda, you must load the
+            ``miniforge`` instead (see :ref:`python-conda-modules`
+            below).
 
     .. tab-item:: Hera
         :sync: hera


### PR DESCRIPTION
This adds a note to let users know that on Gaea the python modules do not include conda.