### PR TITLE
Two fixes for the OpenSSH Sample Configuration Form

### DIFF
--- a/source/connecting/openssh_config.rst
+++ b/source/connecting/openssh_config.rst
@@ -77,7 +77,7 @@ file.
 
             return(`Host ${host}-rsa.boulder.rdhpcs.noaa.gov\n` +
                    `    HostName          ${host}-rsa.boulder.rdhpcs.noaa.gov\n\n` +
-                   `Host ${host}-rsa.princeton.rdhpcs.noaa.gov ${host}-rsa.boulder.rdhpcs.noaa.gov\n` +
+                   `Host ${host}-rsa.princeton.rdhpcs.noaa.gov ${host}-rsa ${host}-rsa ${host}\n` +
                    `    HostName          ${host}-rsa.princeton.rdhpcs.noaa.gov\n` +
                    `    LocalForward      ${lf_port} localhost:${lf_port}\n` +
                    `    RemoteForward     ${rf_port} localhost:22\n` +
@@ -108,7 +108,7 @@ file.
                    ssh_host_conf("hera", user, lf_hera + uid, rf_gaea + uid) +
                    ssh_host_conf("jet", user, lf_jet + uid, rf_jet + uid) +
                    ssh_host_conf("mercury", user, lf_mercury + uid, rf_mercury + uid) +
-                   ssh_host_conf("ppan", user, lf_ppan + uid, rf_ppan + uid) +
+                   ssh_host_conf("analysis", user, lf_ppan + uid, rf_ppan + uid) +
                    ssh_host_conf("ursa", user, lf_ursa + uid, rf_ursa + uid));
         }
 


### PR DESCRIPTION
1. The analysis hostname is "analysis-rsa" not "ppan-rsa".
2. The alias for the princeton bastions is currently confused, including the boulder name as an alias. Instead, set the shorter hostname as an alias (e.g. "analysis-rsa" and "analysis" as aliases for analysis-rsa.princeton.rdhpcs.noaa.gov