### PR TITLE
Added Attention below uDTN table

### DIFF
--- a/source/data/transferring_data.rst
+++ b/source/data/transferring_data.rst
@@ -160,7 +160,10 @@ desktop/laptop. However, note the following important points:
 
   On Mercury and Ursa, the Directory on the host differs from the Directory as
   seen on the uDTN. The final column in the table above shows the data path on
-  a DTN/uDTN, that may differ from the native path on the system.
+  a DTN/uDTN, if it differs from the native path on the system.
+
+
+The final column in the table above shows the data path on a DTN/uDTN if it differs from the native path on the system.
 
 Please note that your project directories are not directly
 accessible from some of the uDTNs, so a two-step transfer

--- a/source/data/transferring_data.rst
+++ b/source/data/transferring_data.rst
@@ -156,6 +156,12 @@ desktop/laptop. However, note the following important points:
      - :file:`/collab1/data_untrusted/$USER`
      -
 
+.. attention::
+
+  On Mercury and Ursa, the Directory on the host differs from the Directory as
+  seen on the uDTN. The final column in the table above shows the data path on
+  a DTN/uDTN, that may differ from the native path on the system.
+
 Please note that your project directories are not directly
 accessible from some of the uDTNs, so a two-step transfer
 is generally required to move data to/from project

--- a/source/data/transferring_data.rst
+++ b/source/data/transferring_data.rst
@@ -162,9 +162,6 @@ desktop/laptop. However, note the following important points:
   seen on the uDTN. The final column in the table above shows the data path on
   a DTN/uDTN, if it differs from the native path on the system.
 
-
-The final column in the table above shows the data path on a DTN/uDTN if it differs from the native path on the system.
-
 Please note that your project directories are not directly
 accessible from some of the uDTNs, so a two-step transfer
 is generally required to move data to/from project


### PR DESCRIPTION
Fixes Issue #585 

RDHPCS#2025080754000156

A user had a problem with the information in the Untrusted Data Transfer Nodes table. The table is too wide for the screen (there's a slider) and she just missed the "Directory as seen on the uDTN" column.
We're adding a alert so readers know that column is there for Mercury and Ursa.