### PR TITLE
Fix Jet CAC bastion hostnames in the table

### DIFF
--- a/source/connecting/index.rst
+++ b/source/connecting/index.rst
@@ -91,8 +91,8 @@ Bastion Hostnames
 .. |HRPRNG|	replace:: hera-rsa.princeton.rdhpcs.noaa.gov
 .. |HRBRNG|	replace:: hera-rsa.boulder.rdhpcs.noaa.gov
 
-.. |JCPRNG|	replace:: jet.princeton.rdhpcs.noaa.gov
-.. |JCBRNG|	replace:: jet.boulder.rdhpcs.noaa.gov
+.. |JCPRNG|	replace:: bastion-jet.princeton.rdhpcs.noaa.gov
+.. |JCBRNG|	replace:: bastion-jet.boulder.rdhpcs.noaa.gov
 .. |JRPRNG|	replace:: jet-rsa.princeton.rdhpcs.noaa.gov
 .. |JRBRNG|	replace:: jet-rsa.boulder.rdhpcs.noaa.gov
 


### PR DESCRIPTION
Initially it was thought "jet" was an alias for "bastion-jet" but that is true only for the Princeton bastion and not the Boulder bastion.  Best to fix the documentation.

The context is this ticket:
https://helpdesk.rdhpcs.noaa.gov/otrs/index.pl?Action=AgentTicketZoom;TicketID=58127