### PR TITLE
updates to Yubikey instructions per issue #630 

### DIFF
--- a/source/accounts/yubikey_token.rst
+++ b/source/accounts/yubikey_token.rst
@@ -232,9 +232,9 @@ You must have completed the registration steps above.
 
 .. note::
 
-    These steps configure your Yubikey for use on RDHPCS systems. 
+    These steps configure your Yubikey for use on RDHPCS systems.
     Once this is done you will generally not need to use your Yubikey Authenticator
-    again, unless you need to reconfigure your Yubikey because you forgot your PIN, 
+    again, unless you need to reconfigure your Yubikey because you forgot your PIN,
     or you replace your Yubikey.
 
 


### PR DESCRIPTION
Based on user experiences following the YubiKey rollout, User Support requested small changes to the Doc:

agreement in title level for YubiKey Authenticator for Windows v Linux
note E in YubiCo section -- note is no longer necessary
final note, once setup is done, you're done with YubiKey

I also did some small style edits. 