### PR TITLE
Add clarification on where Yubikey is needed

### DIFF
--- a/source/accounts/yubikey_token.rst
+++ b/source/accounts/yubikey_token.rst
@@ -24,7 +24,9 @@ physical possession of a key for successful login.
    access the NOAA RDHPCS.  Contact your security office to request a
    Yubikey.
 
-The following services will **require** the use of Yubikey
+Please note that even though either CAC or Yubikey may be used for
+RDHPCS logins,
+the following services will **require** the use of Yubikey
 for authentication as CAC authentication is not
 supported for these services:
 


### PR DESCRIPTION
The above change was made based on the following ticket, and I am sure others will have the same questions:

"Concerning Role accounts (our division within NWS/MDL uses the "role.mdlstat" account) and the new multi-factor authentication, is Yubikey going to be the ONLY way to access such accounts going forward, or can this also be done via CAC as for our regular accounts?  Similarly for data transfers, is Yubikey the only method available for this?"