### PR TITLE
Enhance Yubikey authentication troubleshooting section

### DIFF
--- a/source/accounts/yubikey_token.rst
+++ b/source/accounts/yubikey_token.rst
@@ -278,11 +278,11 @@ Troubleshooting RDHPCS Yubikey Authentication
 ---------------------------------------------
 
 The most common problem that users have had logging in
-with Yubikey is the failure to do the "long touch" 
+with Yubikey is the failure to do the "long touch"
 correctly. These suggestions should help:
 
-* When you're logging into the RHPCS bastions using a 
-  terminal program, **keep touching the key** until the 
+* When you're logging into the RHPCS bastions using a
+  terminal program, **keep touching the key** until the
   cursor moves to the next line.
 * If you're loggin in using a GUIs (Globus login using
   a browser for example) **keep touching the key**


### PR DESCRIPTION
Tried to clarify what "long touch" means with terminal programs that are typically used for bastion authentication and GUIs such as when using a browser for logging into Globus.

Not sure if there are other situations but these are the most common ones I have run into.  X2go is another one but that is on its way out.