### PR TITLE
Update Yubikey token instructions for NOAA compliance

### DIFF
--- a/source/accounts/yubikey_token.rst
+++ b/source/accounts/yubikey_token.rst
@@ -47,8 +47,8 @@ Yubikey Registration
    be using your Yubikey to authenticate into the RDHPCS.  **Your RSA
    token will no longer work.**
 
-The NOAA Yubikey is issued by your security office.  
-Only NOAA issued YubiKeys are allowed to be registered with AIM
+The NOAA Yubikey is issued by your security office. You can only
+register **NOAA-issued YubiKeys** with AIM
 for use with RDHPCS resources.
 
 **If you do not have a NOAA issued Yubikey, contact your local I/T


### PR DESCRIPTION
Clarify that only NOAA issued YubiKeys are allowed for registration with AIM based on feedback from Eric.