### PR TITLE
Update description for u1-service partition - 64 core max

### DIFF
--- a/source/systems/ursa_user_guide.rst
+++ b/source/systems/ursa_user_guide.rst
@@ -111,7 +111,7 @@ Ursa Partitions
    * - u1-service
      - batch, windfall
      - 100
-     - Serial jobs (max 64 cores and/or 250g of memory per user),
+     - Serial jobs (max 64 cores and/or 250 GB of memory per user),
        with a 24 hr wall time limit. Jobs will be run on
        service nodes that have external network connectivity. Useful
        for data transfers or access to external resources like databases.


### PR DESCRIPTION
The service partition will now allow jobs requesting 64 cores or equivalent amount of memory.