### PR TITLE
Update purge warning duration from 30 to 90 days

### DIFF
--- a/source/systems/ursa_user_guide.rst
+++ b/source/systems/ursa_user_guide.rst
@@ -303,7 +303,7 @@ for your applications via the purged directory,
 .. warning::
 
    **This directory will be purged of all files that have not
-   been accessed in the past 30 days**. Depending on usage we
+   been accessed in the past 90 days**. Depending on usage we
    will adjust the purge schedule as needed, preceded by a user
    notification. Users under the ``/purged`` directory have a quota
    of **250 TB**.


### PR DESCRIPTION
Very simple change that was done today to increase the purge time from 30 days to 60 days