### PR TITLE
Consolidate SSH port forwarding docs and add SSH client pages

### DIFF
--- a/source/FAQ/index.rst
+++ b/source/FAQ/index.rst
@@ -638,263 +638,46 @@ forwarding is working by running the command **xclock**.
 Port Tunnels
 ============
 
-How do I set up an ssh port tunnel?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How do I set up an SSH port tunnel?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can only establish an ssh tunnel from your initial bastion session. If you
-try to establish a tunnel and see the messages like this:
+See :ref:`ssh-port-tunnels` for setup instructions and port number
+assignments.
 
-
-  .. code-block:: shell
-
-    -------------------
-    bind [127.0.0.1]:57037: Address already in use
-    channel_setup_fwd_listener_tcpip: cannot listen to port: 57037
-    Could not request local forwarding.
-    -------------------
-
-You will know that you already have an open session, and cannot
-open a tunnel on this bastion.
-
-To establish a new tunnel, do one of the following:
-
-  * Close any existing sessions on this bastion, **or**,
-  * Open a new session using a bastion where you have no existing sessions.
-
-In the steps below, replace First.Last with your own HPC username, and
-XXXXX with the unique Local Port Number assigned to you when you log
-in to your specified HPC system (Hera/Jet/etc). Use the word "localhost"
-where indicated. It is not a variable, don't substitute anything else.
-Before you perform the first step, close all current sessions on the
-HPC system where you are trying to connect. Once the first session has
-been opened with port forwarding, any further connections (login via
-ssh, copy via scp) will work as expected. You are running these
-commands on your local machine, not within the HPC system terminal.
-
-As long as this ssh window remains open, you will be able to use this
-forwarded port for data transfers.
-
-
-**1. Find your local port number**
-
-To find your unique local port number, log onto your specified HPC
-system (Hera/Jet). Make a note of this number - once you've recorded
-it, close all sessions. Note that this number, which is a fixed
-value for you, will be different on each HPC system.
-
-.. image:: /images/linux_xfer1.png
-   :scale: 75%
-
-.. note::
-    Open two terminal windows for this process
-
-**Local Client Window #1**
-
-Enter the appropriate command for your environment. Remember to replace XXXXX
-with the local port number identified in Step 1 or as needed.
-
-For Windows Power Shell, enter:
+You can only establish a tunnel from your initial bastion session.
+If you see this error when connecting:
 
 .. code-block:: shell
 
-     ssh -m hmac-sha2-512-etm@openssh.com -XXXXX:localhost:XXXXX First.Last@bastion_hostname
+   bind [127.0.0.1]:57037: Address already in use
+   channel_setup_fwd_listener_tcpip: cannot listen to port: 57037
+   Could not request local forwarding.
 
+You already have an open session on that bastion.  To establish a new
+tunnel, close your existing session or connect through a different
+bastion.
 
-For Mac or Linux, enter:
+For file transfer commands using an established tunnel, see
+:ref:`established-tunnel`.
 
-.. code-block:: shell
 
-     ssh -L XXXX:localhost:XXXXX First.Last@bastion_hostname
+SSH port tunnel for PuTTY (Windows)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you will be running X11 applications with x2go or normal terminals,
-remember to add the -X parameter as follows:
+See :ref:`ssh-port-tunnels` for PuTTY port tunnel setup instructions.
 
-.. code-block:: shell
+SSH port tunnel for Tectia
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    ssh -X -L XXXX:localhost:XXXXX First.Last@bastion_hostname
+See :ref:`ssh-port-tunnels` for Tectia port tunnel setup instructions.
 
 
-To verify that the tunnel is working, open another local window in your local
-machine, and issue the command:
+How do I transfer small files to or from an RDHPCS system?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: shell
-
-   ssh -p XXXX First.Last@localhost
-
-Note that XXXX is your local port number used above, First.Last is
-your user ID on the RDHPCS systems and localhost is typed as-is.
-
-.. note::
-
-  For a complete list of available bastions by site, check the
-  :ref:`bastion_hostnames` table.
-
-You should be prompted for your password; enter your PIN + RSA token
-and you should be able to login. Once you are able to log in, you can
-log out of that session as that was only for testing the tunnel.
-
-**2. Use SCP to Complete the Transfer**
-
-**Local Client Window #2**
-
-Once the session is open, you can use this forwarded port
-for data transfers, as long as this ssh window is kept open.
-
-Remember that this is the second terminal session opened on your local
-machine. Once a tunnel has been set up as in Step 1, you
-can use a client such as WinSCP to do the transfers using that tunnel.
-Please keep in mind that tunnel will exist only as long as the session opened
-in Step 1 is kept alive.
-
-
-.. code-block:: shell
-
-  Hostname: localhost
-  Port: your-assigned-port-used-in-Step1-above
-  File protocol: SFTP
-
-
-To transfer a file **to** HPC Systems
-
-
-For Windows Power Shell, enter:
-
-.. code-block:: shell
-
-  scp -P XXXXX /local/path/to/file First.Last@localhost:/path/to/file/on/HPCSystems
-
-For Mac or Linux, enter:
-
-.. code-block:: shell
-
-  rsync <put rsync options here> -e 'ssh -l First.Last -p XXXXX' /local/path/to/files First.Last@localhost:/path/to/files/on/HPCSystems
-
-.. note::
-
-   Your username is case sensitive when used in the scp command. Username should be in the form of First.Last.
-
-To transfer a file **from** HPC Systems:
-
-For Windows Power Shell, enter:
-
-.. code-block:: shell
-
-    scp -P XXXXX First.Last@localhost:/path/to/file/on/HPCSystems /local/path/to/file
-
-For Mac or Linux, enter:
-
-.. code-block:: shell
-
-    rsync <put rsync options here> -e 'ssh -l First.Last -p XXXXX' First.Last@localhost:/path/to/files/on/HPCSystems /local/path/to/files
-
-
-In either case, you will be asked for a password. Enter the password
-from your RSA token (not your passphrase). Your response should be
-your PIN+Token code.
-
-
-SSH Port Tunnel For PuTTy Windows Systems
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-PuTTY is an SSH client, used to configure and initiate connection.
-Navigate to a separate tab to install `PuTTY
-<http://www.putty.org/>`_. If you cannot install software on your
-machine, contact your local systems administrator.
-
-**Configuration**
-
-Enter host information to configure an SSH Terminal Session:
-
-.. image:: /images/putty1.png
-   :scale: 75%
-
-1. Enter Username
-In the left pane under Connection, select "Data" and enter your NOAA
-user name as it appears in your NOAA email address. (Ex: First.Last
-if your NOAA email is First.Last@noaa.gov). User name is case
-sensitive - First.Last. If you do not create a username, you will have
-to enter your user name each time your open a session.
-
-.. image:: /images/putty2.png
-   :scale: 75%
-
-Complete the configuration:
-
-* Select "Session" from the top of the left pane.
-* Select "Save" (between Load and Delete).
-
-**Open a First System Session**
-
-Open the session to make sure it's working, and to record your Local
-Port number to complete the Port Tunneling setup.
-
-* Select the configured session from the "Saved Sessions" list. Select
-  Load, then Open.
-* Enter your unique RSA Passcode.
-
-The RSA passcode is your RSA token PIN followed by 8 digits displayed
-on your RSA token. The digits must be on display when you press enter,
-or access will be denied. When you open a new SSH session, wait for
-the RSA token code to refresh before you enter it.
-
-* Find and record your Local Host number.
-*  Click **Exit**, or close the Putty window to end the session.
-
-**Port Tunnel Setup**
-
-To enable data transfers, you will need to set up a Port Tunnel.
-
-* Open Putty.
-* Select the session from the Saved Sessions list, then Load.
-* In the left pane under Connection>SSH select Tunnels.
-* Check Local ports accept connections from other hosts.
-* In the Source Port field, enter your Local Port number
-* In the Destination Port field, enter "localhost:<local port
-  number>", where your local port number matches what was entered in
-  the Source port.
-* Select Local and Auto Radio Buttons.
-* Click the Add Button.
-
-.. image:: /images/putty3.png
-
-To save the configuration change:
-
-* In the left pane, select Session.
-* Select Save.
-
-Select **Open** to Login and verify that the updated session works correctly.
-
-Create a new Port Tunnel for each SSH system you intend to use. Each
-one will have a unique Local Port number.
-
-To add extra saved sessions (ex: for another Bastion) for the same
-system (you already have the Local Port number):
-
-* Load your current saved session
-* Enter the new host name for the other Bastion
-* Give the new session a new name (ex: Jet - Princeton)
-* Select Save. The new session will appear in the list of saved sessions.
-* Select Open to Login and verify the new session works correctly.
-
-
-SSH Port Tunnel For Tectia Windows Systems
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-See the :ref:`tectia` pages for complete information.
-
-
-How to transfer small files to/from an RDHPCS system?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Port Tunnelling approach is useful for transferring small amount
-data to/from RDHPCS systems from your local machine.
-
-Transferring data using scp/WinSCP is a 2 step process:
-
-1. Establish a Tunnel by following the steps documented here:
-2. Transfer file using WinSCP
-
-See the Data Transfer pages for complete information.
+Use the SSH port tunnel method.  First set up a tunnel (see
+:ref:`ssh-port-tunnels`), then transfer files using ``scp`` or
+``rsync`` (see :ref:`established-tunnel`).
 
 I can no longer transfer files via the port tunnel, please help!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,11 +698,8 @@ The number above will match the port you are trying to use.
 To resolve this problem:
 
 #. Exit all ssh sessions from your host
-#. Restart ssh to Jet. This session must have the port tunnel options included
-
-.. code-block:: shell
-
- ssh -L XXXX:localhost:XXXX
+#. Restart your SSH session with the port tunnel options.  See
+   :ref:`ssh-port-tunnels` for the correct command for your platform.
 
 #. Try using scp to transfer a file.
 

--- a/source/connecting/index.rst
+++ b/source/connecting/index.rst
@@ -4,306 +4,424 @@
 Connecting
 ##########
 
-.. _Account Information Management:	https://aim.rdhpcs.noaa.gov
+.. _ssh-overview:
 
-Connecting for the first time
-=============================
+********
+Overview
+********
 
-All connections to the NOAA RDHPCS enclave are done via Secure Shell
-(SSH) in a terminal session to a Bastion, or via a web browser to
-`ParallelWorks <https://noaa.parallel.works>`__.  See our :ref:`ParallelWorks guide <cloud-user-guide>`.
+All RDHPCS on-premise compute systems are accessed through a *bastion
+host* — a secure gateway server between your workstation and the
+compute system.  You connect to the bastion first, and the bastion
+forwards you to the compute system.
+
+.. code-block:: text
+
+   Your workstation  →  Bastion host  →  RDHPCS compute system
+
+RDHPCS supports two authentication methods:
+
+* **Common Access Card (CAC)** — uses your CAC with the Tectia
+  Secure Shell (SSH) client.  Recommended for users who have a CAC
+  and a card reader.
+* **YubiKey** — uses your NOAA-issued YubiKey with a standard SSH
+  client.  Use this method if you don't have a CAC or a card reader.
+
+Within the RDHPCS enclave, `X.509`_ certificates authenticate you
+to individual compute systems.
 
 .. note::
 
-   For access to the MSU HPC systems Orion and Hercules, please review
-   the :ref:`MSU-HPC <MSU-HPC-user-guide>` user guide.
+   Mississippi State University (MSU) hosts the Orion and Hercules
+   systems using a separate login process.  See the
+   :ref:`MSU-HPC user guide <MSU-HPC-user-guide>`.
 
-Authentication is via a :ref:`CAC/PIV card<common-access>` or
-YubiKey Multi-Factor Authentication.
+.. note::
 
-Internal to the enclave, `X509 certificates
-<https://en.wikipedia.org/wiki/X.509>`__ are used to authenticate
-between resources.  At first login, and at yearly intervals, a master
-certificate valid for one year is created (SSH Bastion login required)
-with a user-defined pass-phrase.  At each successive log in, a
-thirty-day proxy certificate is created and used for resource access
-and data transfers.
+   Cloud resources are available through the `Parallel Works`_
+   platform.  See the :ref:`Cloud User Guide <cloud-user-guide>`.
+
+
+.. _prerequisites:
+
+****************
+Before you begin
+****************
+
+Confirm you have the following before connecting for the first time:
+
+* An active RDHPCS account.  Visit `Account Information Management`_
+  (AIM) to view your profile.
+* Access to the RDHPCS system you want to use.  AIM lists the systems
+  your account can access.
+* A CAC and card reader, **or** a registered YubiKey.
+  See :ref:`yubikey-user-instructions` to register your YubiKey.
+* An SSH client installed and configured.
+  See :ref:`ssh-client-selection` below.
 
 .. attention::
 
-   You must have access to an RDHPCS resource (system) in order to log
-   into it!  Visit the `Account Information Management`_ website to
-   view your RDHPCS profile and system access.
+   You must have access to a system before you can log into it.
+   Visit AIM to verify your system access before you begin.
 
 
-Access to most RDHPCS systems require a signed x.509 certificate.  The
-first login attempt will generate a master certificate request.  You
-will experience a short (less than 5 minute) delay while the request
-is signed. Users cannot fully log on to a system until that
-certificate is signed.
+.. _ssh-client-selection:
 
-The prompt will ask you to create a passphrase. Create a passphrase
-with a minimum of three words.
+********************************
+Choose and install an SSH client
+********************************
 
-.. note::
+Your platform and authentication method determine which SSH client to
+use.  See :ref:`ssh-clients` for selection guidance and installation
+instructions for each client.
 
-    Do not worry if you forget your passphrase -- just continue to
-    try.  On the 4th attempt the system will prompt you to recreate
-    your master certificate.
-
-.. _ssh_access:
-
-Secure Shell (SSH) Access
-=========================
-
-Access to on premise RDHPCS compute resources is done using the Secure Shell
-(SSH) protocol to one of the system's bastions, or via ParallelWorks.
-
-MSU systems (Orion, Hercules) are accessed via SSH or OpenOnDemand.
-See MSU-HPC :ref:`MSUHPC-logging-in` for instructions.
-
-SSH clients are available for Windows-based systems, such as published
-by VanDyke software.  For recent SecureCRT versions, the preferred
-authentication setting is shown above.
-
-For Windows systems, `PuTTY
-<https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html>`_,
-`SecureCRT <https://www.vandyke.com/products/securecrt/>`_, or
-`MobaXterm <https://mobaxterm.mobatek.net/>`_ can also be used to
-provide SSH capability.  Recent updates to Windows 10 and Windows 11
-have added built-in support for SSH.  If it is not installed on your
-version of Windows, please refer to Microsoft's `documentation on
-OpenSSH <https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-server-2025>`_.
 
 .. _bastion_hostnames:
 
-Bastion Hostnames
-=================
-.. |CBHN|	replace:: **CAC Bastion hostnames**
-.. |RBHN|	replace:: **RSA Bastion hostnames**
-.. |GCPRNG|	replace:: gaea.princeton.rdhpcs.noaa.gov
-.. |GCBRNG|	replace:: gaea.boulder.rdhpcs.noaa.gov
-.. |GRPRNG|	replace:: gaea-rsa.princeton.rdhpcs.noaa.gov
-.. |GRBRNG|	replace:: gaea-rsa.boulder.rdhpcs.noaa.gov
+*****************
+Bastion hostnames
+*****************
 
-.. |HCPRNG|	replace:: hera.princeton.rdhpcs.noaa.gov
-.. |HCBRNG|	replace:: hera.boulder.rdhpcs.noaa.gov
-.. |HRPRNG|	replace:: hera-rsa.princeton.rdhpcs.noaa.gov
-.. |HRBRNG|	replace:: hera-rsa.boulder.rdhpcs.noaa.gov
+Each RDHPCS system has bastion hosts at two locations: Princeton,
+New Jersey, and Boulder, Colorado.  Either location works for login
+and data transfer.  Choose the location closest to you for the best
+response time.
 
-.. |JCPRNG|	replace:: bastion-jet.princeton.rdhpcs.noaa.gov
-.. |JCBRNG|	replace:: bastion-jet.boulder.rdhpcs.noaa.gov
-.. |JRPRNG|	replace:: jet-rsa.princeton.rdhpcs.noaa.gov
-.. |JRBRNG|	replace:: jet-rsa.boulder.rdhpcs.noaa.gov
+CAC users must connect to a CAC bastion hostname.
+YubiKey users must connect to an RSA bastion hostname.
 
-.. |PPPRNG|	replace:: bastion-analysis.princeton.rdhpcs.noaa.gov
-.. |PPBRNG|	replace:: bastion-analysis.boulder.rdhpcs.noaa.gov
-.. |PAPRNG|	replace:: analysis-rsa.princeton.rdhpcs.noaa.gov
-.. |PBPRNG|	replace:: analysis-rsa.boulder.rdhpcs.noaa.gov
+.. |CBHN|   replace:: **CAC bastion hostnames**
+.. |RBHN|   replace:: **RSA bastion hostnames**
+.. |GCPRNG| replace:: gaea.princeton.rdhpcs.noaa.gov
+.. |GCBRNG| replace:: gaea.boulder.rdhpcs.noaa.gov
+.. |GRPRNG| replace:: gaea-rsa.princeton.rdhpcs.noaa.gov
+.. |GRBRNG| replace:: gaea-rsa.boulder.rdhpcs.noaa.gov
 
-.. |MCPRNG|	replace:: mercury-cac.princeton.rdhpcs.noaa.gov
-.. |MCBRNG|	replace:: mercury-cac.boulder.rdhpcs.noaa.gov
-.. |MRPRNG|	replace:: mercury-rsa.princeton.rdhpcs.noaa.gov
-.. |MRBRNG|	replace:: mercury-rsa.boulder.rdhpcs.noaa.gov
+.. |HCPRNG| replace:: hera.princeton.rdhpcs.noaa.gov
+.. |HCBRNG| replace:: hera.boulder.rdhpcs.noaa.gov
+.. |HRPRNG| replace:: hera-rsa.princeton.rdhpcs.noaa.gov
+.. |HRBRNG| replace:: hera-rsa.boulder.rdhpcs.noaa.gov
 
-.. |UCPRNG|	replace:: ursa-cac.princeton.rdhpcs.noaa.gov
-.. |UCBRNG|	replace:: ursa-cac.boulder.rdhpcs.noaa.gov
-.. |URPRNG|	replace:: ursa-rsa.princeton.rdhpcs.noaa.gov
-.. |URBRNG|	replace:: ursa-rsa.boulder.rdhpcs.noaa.gov
+.. |JCPRNG| replace:: bastion-jet.princeton.rdhpcs.noaa.gov
+.. |JCBRNG| replace:: bastion-jet.boulder.rdhpcs.noaa.gov
+.. |JRPRNG| replace:: jet-rsa.princeton.rdhpcs.noaa.gov
+.. |JRBRNG| replace:: jet-rsa.boulder.rdhpcs.noaa.gov
 
-.. |OUG|	replace:: :ref:`orion-user-guide`
+.. |PPPRNG| replace:: bastion-analysis.princeton.rdhpcs.noaa.gov
+.. |PPBRNG| replace:: bastion-analysis.boulder.rdhpcs.noaa.gov
+.. |PAPRNG| replace:: analysis-rsa.princeton.rdhpcs.noaa.gov
+.. |PBPRNG| replace:: analysis-rsa.boulder.rdhpcs.noaa.gov
+
+.. |MCPRNG| replace:: mercury-cac.princeton.rdhpcs.noaa.gov
+.. |MCBRNG| replace:: mercury-cac.boulder.rdhpcs.noaa.gov
+.. |MRPRNG| replace:: mercury-rsa.princeton.rdhpcs.noaa.gov
+.. |MRBRNG| replace:: mercury-rsa.boulder.rdhpcs.noaa.gov
+
+.. |UCPRNG| replace:: ursa-cac.princeton.rdhpcs.noaa.gov
+.. |UCBRNG| replace:: ursa-cac.boulder.rdhpcs.noaa.gov
+.. |URPRNG| replace:: ursa-rsa.princeton.rdhpcs.noaa.gov
+.. |URBRNG| replace:: ursa-rsa.boulder.rdhpcs.noaa.gov
 
 +-------------------+-----------------+----------------------------------+
-| **RDHPCS System** | |CBHN|          | |RBHN|                           |
+| **RDHPCS system** | |CBHN|          | |RBHN|                           |
 +-------------------+-----------------+----------------------------------+
 | Gaea              | |GCPRNG|        | |GRPRNG|                         |
 |                   |                 |                                  |
 |                   | |GCBRNG|        | |GRBRNG|                         |
 +-------------------+-----------------+----------------------------------+
-| Hera              | |HCBRNG|        | |HRBRNG|                         |
+| Hera              | |HCPRNG|        | |HRPRNG|                         |
 |                   |                 |                                  |
-|                   | |HCPRNG|        | |HRPRNG|                         |
+|                   | |HCBRNG|        | |HRBRNG|                         |
 +-------------------+-----------------+----------------------------------+
-| Jet               | |JCBRNG|        | |JRBRNG|                         |
+| Jet               | |JCPRNG|        | |JRPRNG|                         |
 |                   |                 |                                  |
-|                   | |JCPRNG|        | |JRPRNG|                         |
+|                   | |JCBRNG|        | |JRBRNG|                         |
 +-------------------+-----------------+----------------------------------+
 | PPAN              | |PPPRNG|        | |PAPRNG|                         |
 |                   |                 |                                  |
 |                   | |PPBRNG|        | |PBPRNG|                         |
 +-------------------+-----------------+----------------------------------+
-| Mercury           | |MCBRNG|        | |MRBRNG|                         |
+| Mercury           | |MCPRNG|        | |MRPRNG|                         |
 |                   |                 |                                  |
-|                   | |MCPRNG|        | |MRPRNG|                         |
+|                   | |MCBRNG|        | |MRBRNG|                         |
 +-------------------+-----------------+----------------------------------+
-| Ursa              | |UCBRNG|        | |URBRNG|                         |
+| Ursa              | |UCPRNG|        | |URPRNG|                         |
 |                   |                 |                                  |
-|                   | |UCPRNG|        | |URPRNG|                         |
+|                   | |UCBRNG|        | |URBRNG|                         |
 +-------------------+-----------------+----------------------------------+
 
-In addition to the Bastions, RDHPCS users have access to computational capacity
-on the Orion and Hercules systems, hosted by Mississippi State University. See
-the :ref:`MSU-HPC <MSU-HPC-user-guide>` user guide.
-for detailed information.
 
-Computational capacity is also available on the RDHPCS Cloud Platform, which
-allows NOAA users to create custom HPC clusters on an as-needed basis, through
-the Parallel Works platform. The :ref:`Cloud User Guide <cloud-user-guide>`
-provides more information.
+.. _ssh_access:
+.. _login-instructions:
+
+******
+Log in
+******
+
+.. _first-login:
+
+First login and certificate setup
+==================================
+
+On your first login, RDHPCS creates an `X.509`_ master certificate
+that authenticates you to RDHPCS systems.  The certificate request
+must be signed before you can fully log in.  Signing takes less than
+five minutes.
+
+The system prompts you to create a passphrase for your master
+certificate.  Create a passphrase of at least three words.
+
+.. note::
+
+   Your master certificate is valid for one year.  Each login renews
+   a thirty-day proxy certificate used for resource access and data
+   transfers.
+
+.. note::
+
+   If you forget your passphrase, keep attempting to log in.  On the
+   fourth failed attempt, the system prompts you to regenerate your
+   master certificate.
 
 
 .. _Common-access:
 .. _cac_instructions:
 
-Common Access Card (CAC) SSH Login
-==================================
+Log in with a CAC
+==================
 
-RDHPCS users with a CAC who are logging in from a Windows, Mac, or
-Linux system are recommended to use a CAC login. This requires a CAC
-reader and software from Tectia. If you recently were issued a new CAC
-or renewed CAC, please log into the `Account Information Management`_
-website to update the CAC information.
+CAC login requires a card reader and the :ref:`Tectia <Tectia>` SSH
+client.  Install and configure Tectia before following these steps.
 
-Reference the :ref:`Tectia` pages for complete information on how to
-configure Tectia initially for login using SSH with your CAC.
+#. Find your CAC bastion hostname in the :ref:`bastion_hostnames`
+   table above.
+#. Open a terminal and connect to the bastion:
 
-.. code-block:: console
+   .. code-block:: console
 
-    $ sshg3 CAC-BASTION-HOSTNAME
+      $ sshg3 CAC-BASTION-HOSTNAME
 
-#. Reference the table above for the appropriate CAC Bastion to use.
-#. When prompted, enter your CAC PIN.
+#. When prompted, enter your CAC Personal Identification Number (PIN).
+
+If you recently received a new or renewed CAC, update your card
+information in `Account Information Management`_ before logging in.
 
 
 .. _yubikey_instructions:
 
-Yubikey SSH Login
-=================
+Log in with a YubiKey
+======================
 
-RDHPCS users who do not have a CAC, or lack the required hardware or
-software, are welcome to use their NOAA issued Yubikey to login. You
-must have :ref:`configured and registered your Yubikey for NOAA RDHPCS
-access. <yubikey-user-instructions>`
+:ref:`Configure and register your YubiKey <yubikey-user-instructions>`
+before following these steps.
 
-.. code-block:: console
+#. Find your RSA bastion hostname in the :ref:`bastion_hostnames`
+   table above.
+#. Open a terminal and connect to the bastion:
 
-    $ ssh RSA-BASTION-HOSTNAME
+   .. code-block:: console
+
+      $ ssh RSA-BASTION-HOSTNAME
+
+#. When prompted, enter your YubiKey PIN, then press and hold the
+   YubiKey button (long press).
 
 
-#. The RSA bastions are used for Yubikey logins.
-#. Reference the table above for the appropriate RSA Bastion to use.
-#. When prompted, enter your Yubikey PIN then press and hold your Yubikey
-   (long press).
+.. _select-a-node:
 
-Selecting a Node
-================
+*************
+Select a node
+*************
 
-RDHPCS systems accessed via SSH allow users to select a specific head
-node at login.  After successful authentication at the bastion host, a
-list of available nodes will be displayed with a 5 second delay to
-choose a specific destination.  To select a specific host, press
-Control+C (^C) and enter the desired node.
+After you authenticate at the bastion, a list of available compute
+nodes is displayed.  The bastion waits five seconds, then connects
+you to a node that the load balancer selects.
 
-Here is an example of what the display looks like for the Gaea system
-mid 2024:
+To connect to a specific node, press :kbd:`Control+C` within five
+seconds and enter the node name when prompted.
+
+The following example shows the selection prompt as it appears on the
+Gaea system.  The node list varies by system.
 
 .. code-block:: shell
 
+   Welcome to the NOAA RDHPCS.
 
-     Welcome to the NOAA RDHPCS.
+   Attempting to renew your proxy certificate...
+   Proxy certificate has 720:00:00  (30.0 days) left.
 
-     Attempting to renew your proxy certificate...Proxy certificate has 720:00:00  (30.0 days) left.
+           Welcome to gaea.rdhpcs.noaa.gov
+   Gateway to gaea-c5.ncrc.gov and other points beyond
 
-             Welcome to gaea.rdhpcs.noaa.gov
-     Gateway to gaea-c5.ncrc.gov and other points beyond
+   Hostname            Description
+   gaea                C5 head nodes
+   gaea51              C5 head node
+   gaea52              C5 head node
+   ...
+   gaea61              C6 head node
+   ...
 
-     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-     !! RDHPCS Policy states that all user login sessions shall be terminated     !!
-     !! after a maximum duration of seven (7) days. ALL user login sessions will  !!
-     !! be dropped from the Princeton Bastions at 4AM ET / 2AM MT each Monday     !!
-     !! morning, regardless of the duration. Please note: This will NOT impact    !!
-     !! batch jobs, cron scripts, screen sessions, remote desktop, or data        !!
-     !! transfers.                                                                !!
-     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-     Hostname            Description
-     gaea                C5 head nodes
-     gaea51              C5 head node
-     gaea52              C5 head node
-     gaea53              C5 head node
-     gaea54              C5 head node
-     gaea55              C5 head node
-     gaea56              C5 head node
-     gaea57              C5 head node
-     gaea58              C5 head node
-     gaea60              T6 Test access only
-     gaea61              C6 head node
-     gaea62              C6 head node
-     gaea63              C6 head node
-     gaea64              C6 head node
-     gaea65              C6 head node
-     gaea66              C6 head node
-     gaea67              C6 head node
-     gaea68              C6 head node
-
-     You will now be connected to NOAA RDHPCS: Gaea (CMRS/NCRC) C5 system.
-     To select a specific host, hit ^C within 5 seconds.
-
+   To select a specific host, hit ^C within 5 seconds.
 
 .. note::
 
-    After the 5 second wait, the bastion node will use a load balancer to select
-    a node.
+   After five seconds, the bastion connects you to the load-balanced
+   default node.  See the user guide for your system for the complete
+   list of available nodes.
 
-
-X11 Graphics
-============
-
-Users can use SSH X11 forwarding to open GUI-based applications (e.g., xterm,
-ARM Forge).  This is typically done using an SSH option.  For the :ref:`Tectia`
-client :command:`sshg3` or OpenSSH-based clients, use the ``-X`` option:
-
-.. code-block:: console
-
-    $ sshg3 -X host.url
-
-or
-
-.. code-block:: console
-
-    $ ssh -X host.url
-
-Other clients, like PuTTY, will have an option when configuring the host.
-
-The base SSH X11 forwarding is typically slow.  RDHPCS systems use X2Go for
-improved X11 performance.  Some users have found it difficult to use X2Go.
-Please submit a :ref:`support issue <getting_help>` if you have issues using
-X2Go.
-
-.. note::
-
-    Microsoft Windows users can use any of the X11 servers available for
-    Windows.  The SSH client will need to be configured to use the X11 server
-    for forwarding X11.
 
 .. _ssh-port-tunnels:
 
-SSH Port Tunnels
-================
+****************
+SSH port tunnels
+****************
 
-To allow users to easily transfer small files to and from the RDHPCS
-systems, the bastion configures SSH port-forwarding tunnels.  To use these
-tunnels, the user must configure their local SSH client to create tunnels
-to/from the bastion.
+RDHPCS bastions support SSH port forwarding, also called *port
+tunneling*.  Port tunnels let you:
 
-See the Port Tunnel section of the :ref:`Tectia` page for details.  You can use
-:ref:`this form <openssh-config>` to create a sample SSH configuration for
-OpenSSH-based clients.
+* Transfer files using tools like :command:`scp` and :command:`rsync`.
+* Use remote development tools such as
+  :ref:`VS Code Remote-SSH <rdhpcs-VSCode>` and the
+  :ref:`ARM Forge debugger <linaro-forge>`.
+* Access Jupyter notebooks running on compute nodes.
+* Forward other network services between your workstation and RDHPCS
+  systems.
+
+.. note::
+
+   SSH port forwarding is not supported on MSU HPC systems
+   (Orion and Hercules).
+
+Port assignment
+===============
+
+Each user gets unique port numbers calculated from a base port for
+each system and your user ID (UID).  Run :command:`id -u` on any
+RDHPCS system to find your UID.
+
+**Port formula:** LocalForward port = base port + UID
+
+If the result exceeds 65,535, the port wraps around:
+port = (base port + UID - 65,535) + 2,000.
+
+.. list-table:: Port tunnel base ports by system
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - System
+     - LocalForward base port
+     - RemoteForward base port
+   * - Gaea
+     - 30,000
+     - 20,000
+   * - Hera
+     - 45,000
+     - 55,000
+   * - Jet
+     - 11,300
+     - 21,300
+   * - Mercury
+     - 25,000
+     - 35,000
+   * - PPAN
+     - 40,000
+     - 50,000
+   * - Ursa
+     - 35,000
+     - 45,000
+
+Use the :ref:`OpenSSH configuration form <openssh-config>` to
+generate a complete SSH configuration with your port assignments
+already calculated.  Your assigned port numbers also appear in the
+login banner each time you connect.
+
+Set up port tunnels
+===================
+
+For client-specific port tunnel setup, see:
+
+* :ref:`openssh-client` — OpenSSH on Linux, macOS, and Windows
+* :ref:`putty-client` — PuTTY on Windows
+* :ref:`Tectia` — Tectia on Windows, macOS, and Linux
+
+.. warning::
+
+   The tunnels are active only while this SSH session remains open.
+   Closing the terminal window or letting the session time out
+   disconnects all tunnels.  Keep this session running the entire
+   time you need access.
+
+To verify a tunnel, open a second terminal and connect through the
+local port:
+
+.. code-block:: console
+
+   $ ssh -p LOCAL-PORT First.Last@localhost
+
+Replace ``LOCAL-PORT`` with your calculated LocalForward port for
+the system.  You are prompted for your normal credentials (PIN + RSA
+token or YubiKey).  A successful login confirms the tunnel is working.
+You can log out of the test session immediately.
 
 
+.. _x11-graphics:
 
-Web based ParallelWorks Access
-==============================
+***********************
+X11 and remote graphics
+***********************
 
-See the :ref:`cloud-user-guide` for details on using ParallelWorks in
-a web browser to access on-premise and cloud HPCS.
+SSH X11 forwarding lets you run graphical applications on RDHPCS
+systems and display them on your local workstation.
+
+For X11 setup with your SSH client, see :ref:`openssh-x11`,
+:ref:`putty-x11`, or :ref:`tectia-x11`.
+
+Windows X11 servers
+===================
+
+To display graphical output on Windows, an X11 server must be running
+on your workstation before you connect.  Options include:
+
+* `MobaXterm`_ — includes a built-in X11 server.  No separate
+  installation is needed.
+* `VcXsrv`_ — a free, open-source X11 server for Windows.
+
+X2Go
+====
+
+Basic X11 forwarding can be slow over high-latency connections.
+RDHPCS systems support X2Go for faster graphical application
+performance.
+
+.. .. TODO: Add a dedicated X2Go setup and usage guide.
+
+If you have trouble with X2Go, :ref:`contact the help desk
+<getting_help>`.
+
+
+.. _web-based-access:
+
+****************
+Web-based access
+****************
+
+The RDHPCS Cloud Platform is available from a web browser through the
+`Parallel Works`_ platform.  `Parallel Works`_ lets you create and
+manage on-demand High Performance Computing (HPC) clusters without an
+SSH connection.
+
+See the :ref:`Cloud User Guide <cloud-user-guide>` for details.
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   SSH Clients <ssh_clients/index>
+
+
+.. _Account Information Management: https://aim.rdhpcs.noaa.gov
+.. _X.509: https://en.wikipedia.org/wiki/X.509
+.. _MobaXterm: https://mobaxterm.mobatek.net/
+.. _VcXsrv: https://sourceforge.net/projects/vcxsrv/
+.. _Parallel Works: https://noaa.parallel.works

--- a/source/connecting/ssh_clients/index.rst
+++ b/source/connecting/ssh_clients/index.rst
@@ -1,0 +1,65 @@
+.. _ssh-clients:
+
+***********
+SSH Clients
+***********
+
+Your platform and authentication method determine which SSH client to
+use to connect to RDHPCS systems.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 10 40
+
+   * - Platform
+     - Client
+     - CAC
+     - Notes
+   * - Windows
+     - :ref:`openssh-client` (built-in)
+     - No
+     - Included in Windows 10 and later.  Open with PowerShell or
+       Windows Terminal.  Use the
+       :ref:`OpenSSH configuration form <openssh-config>` to generate
+       ``~/.ssh/config``.
+   * - Windows
+     - :ref:`putty-client`
+     - No
+     - Free, open-source graphical SSH client.
+   * - Windows
+     - `MobaXterm`_
+     - No
+     - Includes a built-in X11 server.  Useful for X11 forwarding.
+   * - Windows
+     - `SecureCRT`_
+     - No
+     - Commercial SSH client from VanDyke Software.
+   * - Windows, macOS, Linux
+     - :ref:`Tectia`
+     - Yes
+     - Required for CAC authentication.  RDHPCS provides two licenses
+       per user.
+   * - macOS, Linux
+     - :ref:`openssh-client` (built-in)
+     - No
+     - Pre-installed on macOS and Linux.  No installation needed.
+
+After installing your client, configure it for RDHPCS:
+
+* **OpenSSH users** — use the
+  :ref:`OpenSSH configuration form <openssh-config>` to generate a
+  ready-to-use ``~/.ssh/config`` file with port assignments already
+  calculated for each system.
+* **Tectia users** — follow the :ref:`Tectia setup guide <Tectia>`
+  for installation, configuration, and port forwarding.
+
+.. toctree::
+   :maxdepth: 1
+
+   OpenSSH <openssh/index>
+   Tectia <tectia/index>
+   PuTTY <putty/index>
+
+
+.. _MobaXterm: https://mobaxterm.mobatek.net/
+.. _SecureCRT: https://www.vandyke.com/products/securecrt/

--- a/source/connecting/ssh_clients/openssh/index.rst
+++ b/source/connecting/ssh_clients/openssh/index.rst
@@ -1,0 +1,175 @@
+.. _openssh-client:
+
+*******
+OpenSSH
+*******
+
+OpenSSH is a free, open-source SSH implementation included by default
+on macOS, most Linux distributions, and Windows 10 and later.
+
+
+Install OpenSSH
+===============
+
+OpenSSH is pre-installed on macOS and most Linux distributions.  No
+additional installation is needed on those platforms.
+
+On Windows 10 (version 1809 and later) and Windows 11, OpenSSH is
+available in PowerShell and Windows Terminal.  Verify it is installed:
+
+.. code-block:: console
+
+   > ssh -V
+
+If the command is not found, see `Windows OpenSSH`_ for installation
+instructions.
+
+
+Configure for RDHPCS
+=====================
+
+Use the :ref:`OpenSSH configuration form <openssh-config>` to
+generate your ``~/.ssh/config`` file.  The form calculates your
+unique port numbers and writes ``LocalForward`` and ``RemoteForward``
+directives for each RDHPCS system.
+
+A generated host entry looks like this:
+
+.. code-block:: text
+
+   Host hera-rsa.boulder.rdhpcs.noaa.gov
+       User              First.Last
+       LocalForward      LOCAL-PORT localhost:LOCAL-PORT
+       RemoteForward     REMOTE-PORT localhost:REMOTE-PORT
+
+After you copy the generated configuration into ``~/.ssh/config``,
+connect to an RSA bastion to open the tunnels:
+
+.. code-block:: console
+
+   $ ssh RSA-BASTION-HOSTNAME
+
+See :ref:`bastion_hostnames` for RSA bastion hostnames.
+
+
+.. _openssh-x11:
+
+X11 forwarding
+==============
+
+Add the ``-X`` flag to enable X11 forwarding when you connect:
+
+.. code-block:: console
+
+   $ ssh -X RSA-BASTION-HOSTNAME
+
+To open a port tunnel and enable X11 forwarding in the same session,
+combine ``-X`` and ``-L``:
+
+.. code-block:: console
+
+   $ ssh -X -L LOCAL-PORT:localhost:LOCAL-PORT RSA-BASTION-HOSTNAME
+
+.. note::
+
+   Before using X11 forwarding, make sure you have an X11 server
+   available on your workstation:
+
+   * **Linux** — X11 is available if a desktop environment is running.
+   * **macOS** — install `XQuartz`_.
+   * **Windows** — install `VcXsrv`_ or `MobaXterm`_.
+
+
+Port tunnels
+============
+
+See :ref:`ssh-port-tunnels` for your LocalForward port number and the
+port assignment formula.
+
+Using ``~/.ssh/config``
+-----------------------
+
+If you used the configuration form, ``LocalForward`` is already in
+your ``~/.ssh/config``.  Connect normally to open the tunnel:
+
+.. code-block:: console
+
+   $ ssh RSA-BASTION-HOSTNAME
+
+.. note::
+
+   Windows PowerShell users must add
+   ``-m hmac-sha2-512-etm@openssh.com`` to specify the MAC algorithm:
+
+   .. code-block:: console
+
+      > ssh -m hmac-sha2-512-etm@openssh.com RSA-BASTION-HOSTNAME
+
+   To avoid typing the flag every time, add a ``MACs`` line to the
+   host block in ``~/.ssh/config``:
+
+   .. code-block:: text
+
+      Host RSA-BASTION-HOSTNAME
+          MACs    hmac-sha2-512-etm@openssh.com
+
+.. warning::
+
+   Tunnels are active only while this SSH session remains open.
+   Keep the session running the entire time you need tunnel access.
+
+Manual tunnel command
+---------------------
+
+If you prefer to pass tunnel options on the command line instead of
+using ``~/.ssh/config``, use the ``-L`` flag.  Replace ``LOCAL-PORT``
+with your LocalForward port (see :ref:`ssh-port-tunnels`) and
+``RSA-BASTION-HOSTNAME`` with the hostname from the
+:ref:`bastion_hostnames` table.
+
+*Linux and macOS:*
+
+.. code-block:: console
+
+   $ ssh -L LOCAL-PORT:localhost:LOCAL-PORT \
+     First.Last@RSA-BASTION-HOSTNAME
+
+*Windows PowerShell:*
+
+.. code-block:: console
+
+   > ssh -m hmac-sha2-512-etm@openssh.com `
+     -L LOCAL-PORT:localhost:LOCAL-PORT `
+     First.Last@RSA-BASTION-HOSTNAME
+
+Verify the tunnel
+-----------------
+
+In a second terminal, connect through the local port:
+
+.. code-block:: console
+
+   $ ssh -p LOCAL-PORT First.Last@localhost
+
+You are prompted for your normal credentials (PIN + RSA token or
+YubiKey).  A successful login confirms the tunnel works.  Log out of
+the test session immediately.
+
+
+Reference
+=========
+
+* `OpenSSH website <https://www.openssh.com/>`__ — project home and
+  documentation
+* `ssh manual page <https://man.openbsd.org/ssh>`__ — full command
+  reference
+* `ssh_config manual page <https://man.openbsd.org/ssh_config>`__ —
+  configuration file reference
+* `Windows OpenSSH`_ — installation and setup for Windows
+
+
+.. _Windows OpenSSH:
+   https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui
+.. _XQuartz: https://www.xquartz.org/
+.. _VcXsrv: https://sourceforge.net/projects/vcxsrv/
+.. _MobaXterm: https://mobaxterm.mobatek.net/

--- a/source/connecting/ssh_clients/putty/index.rst
+++ b/source/connecting/ssh_clients/putty/index.rst
@@ -1,0 +1,127 @@
+.. _putty-client:
+
+*****
+PuTTY
+*****
+
+.. attention::
+
+   These instructions are for users already familiar with PuTTY who
+   want to use it with RDHPCS systems.
+
+`PuTTY`_ is a free, open-source SSH client for Windows.
+
+.. note::
+
+   PuTTY is not compatible with VS Code Remote-SSH.  Use
+   :ref:`openssh-client` instead if you use VS Code.
+
+
+Install PuTTY
+=============
+
+Download the installer from the `PuTTY`_ website and run it,
+accepting the default installation options.  If you cannot install
+software on your workstation, contact your local IT administrator.
+
+
+Configure for RDHPCS
+=====================
+
+Find your bastion hostname in the :ref:`bastion_hostnames` table
+before you start.
+
+Create a saved session
+-----------------------
+
+#. Open PuTTY.
+#. In the **Session** category, enter the bastion hostname in the
+   **Host Name** field.  Leave **Port** set to ``22``.
+
+   .. figure:: /images/putty1.png
+
+#. In the left pane, select **Connection > Data**.  Enter your RDHPCS
+   username in **Auto-login username**.  Use the ``First.Last``
+   format; the username is case sensitive.
+
+   .. figure:: /images/putty2.png
+
+#. In the left pane, select **Session**.  Type a name in the **Saved
+   Sessions** field — for example, ``Jet-Boulder`` — then click
+   **Save**.
+#. Click **Open** to test the connection.
+
+
+.. _putty-x11:
+
+X11 forwarding
+==============
+
+You must install and start a Windows X11 server (`VcXsrv`_ or
+`MobaXterm`_) before you connect.  Start the X11 server before
+following these steps.
+
+#. Open PuTTY and load your saved session.
+#. In the left pane, navigate to **Connection > SSH > X11**.
+#. Check **Enable X11 forwarding**.
+#. In the left pane, select **Session**, then click **Save**.
+#. Click **Open** to connect.
+
+
+Set up port tunnels
+===================
+
+See :ref:`ssh-port-tunnels` for your LocalForward port number before
+completing these steps.
+
+#. Open PuTTY.  Select your saved session from the **Saved Sessions**
+   list, then click **Load**.
+#. In the left pane, navigate to **Connection > SSH > Tunnels**.
+#. In the **Source port** field, enter your LocalForward port number.
+#. In the **Destination** field, enter ``localhost:LOCAL-PORT``,
+   replacing ``LOCAL-PORT`` with the same number you entered in
+   step 3.
+#. Select the **Local** radio button.
+
+   .. note::
+
+      If tools on other machines on your local network must reach this
+      tunnel, also check **Local ports accept connections from other
+      hosts**.  For most users this is not required.
+
+#. Click **Add**.
+
+   .. figure:: /images/putty3.png
+
+#. In the left pane, select **Session**, then click **Save**.
+#. Click **Open** to connect.  Verify the tunnel from a second
+   terminal (see :ref:`ssh-port-tunnels`).
+
+.. warning::
+
+   Tunnels are active only while this PuTTY session remains open.
+   Closing the window disconnects the tunnel.
+
+Create a separate saved session for each RDHPCS system, because each
+system has a different LocalForward port number.
+
+To add a second bastion for the same system:
+
+#. Load the existing saved session.
+#. Change **Host Name** to the other bastion hostname.
+#. Enter a new name in **Saved Sessions** — for example,
+   ``Jet-Princeton`` — then click **Save**.
+#. Click **Open** to verify the new session works.
+
+
+Reference
+=========
+
+* `PuTTY documentation`_ — PuTTY user manual
+
+
+.. _PuTTY: https://www.putty.org/
+.. _PuTTY documentation:
+   https://www.chiark.greenend.org.uk/~sgtatham/putty/docs.html
+.. _VcXsrv: https://sourceforge.net/projects/vcxsrv/
+.. _MobaXterm: https://mobaxterm.mobatek.net/

--- a/source/connecting/ssh_clients/tectia/index.rst
+++ b/source/connecting/ssh_clients/tectia/index.rst
@@ -13,8 +13,8 @@ purchased for each RDHPCS user.
 
 The following features are supported:
 
-* Port forwarding
 * X11 tunneling
+* Port forwarding (see :ref:`ssh-port-tunnels`)
 
 Access to RDHPCS Systems from a system which cannot directly access a
 user's CAC is not supported.
@@ -38,7 +38,6 @@ section describe how to do the following:
 * Install the license file on your local laptop or workstation
 * Configure the Tectia software
 * Use the client software to connect to R&D HPC Systems
-* Set up port tunneling
 
 Locate the CAC-bastion hostname you need in the :ref:`bastion_hostnames`
 table. Then follow the instructions for your operating system.
@@ -508,101 +507,107 @@ Configure the Tectia Client
 If successful you will see the message “Authentication successful.”
 You will be forwarded to a front-end host.
 
-.. ref: port_tunnels
+Port tunnels
+============
 
-Port Tunnelling
-===============
+See :ref:`ssh-port-tunnels` for your LocalForward port number and
+the port assignment formula.
 
-If you plan to do file transfers from non-NOAA domains, or if you plan
-to use remote Desktop features (such as X2Go), you will have to set
-port forwarding for each profile.  Please keep in mind that different
-bastions use different port numbers. Log in to each specific host to
-make sure you have your correct port number.
+.. tab-set::
 
-* Select the "Tunneling" Tab
-* Select "Use Defaults" so that it will use the X11 forwarding setting
-  that is set in Default Setting
-* Select the "Add" button
+   .. tab-item:: macOS and Linux
+      :sync: macos
 
-In the steps below, replace "12345" with the unique **local port**
-number assigned to you when you login to Jet. Port numbers are
-dependent on the host you are trying to connect.
+      #. Open your connection profile and select the **Tunneling**
+         tab.
+      #. Check **Use Defaults**.
+      #. Click **Add** and fill in the tunnel settings:
 
-* "Type"= TCP
-* "Listen Port"= 12345
-* Select "Allow local connections only"
-* "Destination host"=localhost
-* "Destination port"= 12345
+         * **Type:** TCP
+         * **Listen port:** your LocalForward port for this system
+         * **Allow local connections only:** checked
+         * **Destination host:** ``localhost``
+         * **Destination port:** same as the Listen port
 
-Click "OK". This will populate the "Local Tunnels" tab in the
-configuration window:
+         .. figure:: /images/mactectia5.png
 
-.. figure:: /images/mactectia5.png
+      #. Click **OK**, then click **Apply** to save the profile.
 
-* Click "Apply" to save the profile
+      Repeat these steps for each connection profile you use.
 
-Repeat these steps for each profile you create.
+   .. tab-item:: Windows
+      :sync: windows
 
-Set Up Port Tunnelling
-----------------------
+      #. Open your connection profile and select the **Tunneling**
+         tab.
 
-Complete the following sequence to set up port tunnelling.
+         .. figure:: /images/tectiawin6.png
 
-1. Edit your connection profile. Navigate to the "Tunneling" tab.
+      #. Check **Use Defaults**.  Confirm that **Tunnel X11
+         connections** and **Allow Agent Forwarding** are checked.
 
-   .. figure:: /images/tectiawin6.png
+         .. figure:: /images/tectiawin7.png
 
-2. Check "Use Defaults". Tunnel X11 connections" and "Allow Agent
-   Forwarding" should be checked. If not, check them.
+      #. Click **Add** and fill in the tunnel settings:
 
-   .. figure:: /images/tectiawin7.png
+         * **Type:** TCP
+         * **Listen port:** your LocalForward port for this system
+         * **Allow local connections only:** checked
+         * **Destination host:** ``127.0.0.1``
+         * **Destination port:** same as the Listen port
 
-3. Select "Add".
+         .. figure:: /images/tectiawin8.png
 
-   * Select "TCP" for Type
-   * Listen Port should match your Local port number listed on your
-     session login.
-   * Check "Allow local connections only"
-   * Destination host: 127.0.0.1
-   * Destination Port should match your Local port number listed on
-     your session login.
+      #. Click **OK**.
+      #. Click **Test connection** to verify the tunnel is active.
 
-     .. figure:: /images/tectiawin8.png
+         .. figure:: /images/tectiawin9.png
 
-   * Select "OK"
+         The completed configuration looks like the following:
 
-4. Selecting "Test connection" to test.
+         .. figure:: /images/tectiawin10.png
 
-   .. figure:: /images/tectiawin9.png
+      #. Click **Apply** to save the profile.
 
-   * Completed configuration should look like the following:
+      Repeat these steps for each connection profile you use.
 
-   .. figure:: /images/tectiawin10.png
 
-Once the session is open, you will be able to use this forwarded port
-for data transfers as long as this ssh window is kept open. After the
-first session has been opened with the port forwarding, any further
-connections (login via ssh, copy via scp) will work as expected.
+.. _tectia-x11:
 
-Testing Port Tunnels
---------------------
+X11 forwarding
+==============
 
-Once you have set up port tunneling, it's useful test that the tunnel
-has been established correctly.
+X11 forwarding is enabled by default when **Use Defaults** is checked
+in the **Tunneling** tab of your connection profile (covered in the
+Configure section above).
 
-To do this, after the port tunnel has been established, try to login using the
-local host and port combination. Please keep in mind you will have to use
-YubiKey Multi-Factor authentication for this test. You should try to connect
-using the following settings with your ssh client (with Windows you could use a
-client like putty, and with linux/Mac you should use ssh):
+To connect with explicit X11 forwarding from the command line, add
+the ``-X`` flag to ``sshg3``:
 
-* Host: localhost (This is literal string, that is, enter the word
-  "localhost")
-* Port: Your-assigned-local-port-on-hera-jet (This is the number
-  listed as Local Port when you login)
-* User: Your user name
+.. code-block:: console
 
-When prompted, enter your User Name and Password, and authenticate
-with YubiKey. If you're
-able to login successfully and see your home directory, that confirms
-that your port tunneling is correct.
+   $ sshg3 -X CAC-BASTION-HOSTNAME
+
+.. note::
+
+   You need an X11 server running on your local workstation before
+   you connect:
+
+   * **Windows** — install `VcXsrv`_ or `MobaXterm`_.
+   * **macOS** — install `XQuartz`_.
+   * **Linux** — X11 is available if a desktop environment is running.
+
+
+Reference
+=========
+
+* `Tectia SSH Client documentation
+  <https://www.ssh.com/products/tectia-ssh/>`__ — official product
+  documentation
+* `AIM <https://aim.rdhpcs.noaa.gov>`__ — manage CAC information and
+  account details
+
+
+.. _VcXsrv: https://sourceforge.net/projects/vcxsrv/
+.. _MobaXterm: https://mobaxterm.mobatek.net/
+.. _XQuartz: https://www.xquartz.org/

--- a/source/data/transfers.rst
+++ b/source/data/transfers.rst
@@ -131,14 +131,13 @@ copying to copy data from an remote host to an RDHPCS host.
 Port Tunnelling
 ---------------
 
-In the SSH port tunnel method, an SSH tunnel is created between your
-point of login (typically your desktop) to the remote host (typically
-Ursa, Jet or other remote hosts). The port tunnel method works
-from any system on the network (that is, your local machine does not
-necessarily have to be in the noaa.gov domain). We recommend using
-this method when the options above are not available or
-are not optimal for your use case.  Please see the
-Transferring Data page for complete details.
+SSH port tunneling creates a secure tunnel between your workstation
+and an RDHPCS system.  This method works from any network — your
+workstation doesn't need to be in the noaa.gov domain.  Use this
+method when Globus and DTN are not available or suitable.
+
+See :ref:`ssh-port-tunnels` to set up a port tunnel, then use the
+transfer commands in the :ref:`established-tunnel` section below.
 
 .. _requests_for_firewall_exceptions:
 
@@ -550,296 +549,75 @@ If you have difficulties, contact the support staff for help.
 
 .. _established-tunnel:
 
-Using a Pre-Established SSH Port Tunnel
-=======================================
+Using a pre-established SSH port tunnel
+========================================
 
-With the SSH port tunnel method, an SSH tunnel is created
-between your point of login (typically your desktop) to the remote
-host (typically Ursa, Jet or another remote host). The port tunnel
-method will work from any system on the network (that is, your local
-machine does not necessarily have to be in the noaa.gov domain). We
-recommend using this in cases where DTN is not accessible.
+Before you transfer files using this method, set up an SSH port
+tunnel from your workstation to the RDHPCS system.  See
+:ref:`ssh-port-tunnels` for setup instructions and your assigned
+port numbers.
+
+.. note::
+
+   Only the first SSH session to a bastion can establish a tunnel.
+   If you see ``Address already in use``, close your existing session
+   or connect through a different bastion.
 
 .. _ssh-tunnel:
 
-SSH Port Tunnel from Linux-like systems
----------------------------------------
-This method requires two sessions on your local machine: one to
-establish the SSH port tunnel, and the other to actually perform the
-copy. To establish the port tunnel, you will need to
-get the appropriate bastion hostname (CAC or RSA) for the host
-you need from the :ref:`bastion_hostnames` table.
+Transfer commands
+-----------------
 
-Before You Begin
-^^^^^^^^^^^^^^^^^
+The commands below work once a port tunnel is active.  Replace
+``LOCAL-PORT`` with your LocalForward port for the system and
+``First.Last`` with your RDHPCS username.
 
-Only the first session to a bastion can establish an ssh tunnel.
-You will know that you already have an
-existing session when you see messages like
+To transfer a file **to** an RDHPCS system:
 
-  .. code-block:: shell
+*Windows PowerShell:*
 
-    -------------------
-    bind [127.0.0.1]:57037: Address already in use
-    channel_setup_fwd_listener_tcpip: cannot listen to port: 57037
-    Could not request local forwarding.
-    -------------------
+.. code-block:: console
 
-To establish a new tunnel, do one of the following:
+   $ scp -P LOCAL-PORT /local/path/to/file First.Last@localhost:/path/on/hpc/
 
+*macOS and Linux:*
 
-  * Close any existing sessions
-  * Open a new session using a bastion where you have no existing sessions.
+.. code-block:: console
 
-In the steps below, replace First.Last with your own HPC username, and
-XXXXX with the unique Local Port Number assigned to you when you log
-in to your specified HPC system (Ursa/Jet). Use the word "localhost"
-where indicated. It is not a variable, don't substitute anything else.
-Before you perform the first step, close all current sessions on the
-HPC where system you are trying to connect. Once the first session has
-been opened with port forwarding, any further connections (login via
-ssh, copy via scp) will work as expected. You are running these
-commands on your local machine, not within the HPC system terminal.
+   $ rsync -e 'ssh -l First.Last -p LOCAL-PORT' /local/path/to/file \
+     First.Last@localhost:/path/on/hpc/
 
-As long as this ssh window remains open, you will be able to use this
-forwarded port for data transfers. After the first session has been
-opened with the port forwarding, any further connections (login via
-ssh, copy via scp) will work as expected.
+To transfer a file **from** an RDHPCS system:
 
-**1. Find your local port number**
+*Windows PowerShell:*
 
-To find your unique local port number, log onto your specified HPC
-system (Ursa/Jet). Make a note of this number - once you've recorded
-it, close all sessions. Note that this number will be different on Jet and
-Ursa.
+.. code-block:: console
 
-.. image:: /images/linux_xfer1.png
-   :scale: 75%
+   $ scp -P LOCAL-PORT First.Last@localhost:/path/on/hpc/file /local/path/
 
-.. note::
-    Open two terminal windows for this process
+*macOS and Linux:*
 
-**Local Client Window #1**
+.. code-block:: console
 
-Enter the appropriate command for your environment. Remember to replace XXXXX
-with the local port number identified in Step 1 or as needed.
-
-For Windows Power Shell, enter:
-
-.. code-block:: shell
-
-     ssh -m hmac-sha2-512-etm@openssh.com -LXXXXX:localhost:XXXXX First.Last@ursa-rsa.boulder.rdhpcs.noaa.gov
-
-For Mac or Linux, enter:
-
-.. code-block:: shell
-
-     ssh -LXXXX:localhost:XXXXX First.Last@ursa-rsa.boulder.rdhpcs.noaa.gov
-
-If you will be running X11 applications with x2go or normal terminals,
-remember to add the -X parameter as follows:
-
-.. code-block:: shell
-
-    ssh -X -LXXXXX:localhost:XXXXX First.Last@ursa-rsa.boulder.rdhpcs.noaa.gov
-
-Note that objects emphasized in this figure should be unique to your
-configuration:
-
-.. image:: /images/linux_xfer2.png
-   :scale: 75%
-
-Verify that the tunnel is working by doing the following in another local
-window from your local machine:
-
-.. code-block:: shell
-
-   ssh -p <port> First.Last@localhost
-
-
-Note that <port> is your local port number used above, First.Last is
-your user ID on the RDHPCS systems and localhost is typed as-is.
-
-You should be prompted for your password; enter your PIN + RSA token
-and you should be able to login. Once you are able to log in, you can
-log out of that session as that was only for testing the tunnel.
-
-**2. Use SCP to Complete the Transfer**
-
-**Local Client Window #2**
-
-Once the session is open, you can use this forwarded port
-for data transfers, as long as this ssh window is kept open. After the
-first session has been opened with the port forwarding, any
-further connections (login via ssh, copy via scp) will work as
-expected.
-
-
-Remember that this is the second terminal session opened on your local
-machine. Once a tunnel has been set up as in Step 1, you
-can use a client such as WinSCP to do the transfers using that tunnel.
-Please keep in mind that tunnel will exist only as long as the session opened
-in Step 1 is kept alive.
-
-
-.. code-block:: shell
-
-  Hostname: localhost
-  Port: your-assigned-port-used-in-Step1-above
-  File protocol: SFTP
-
-
-
-
-To transfer a file **to** HPC Systems
-
-
-For Windows Power Shell, enter:
-
-.. code-block:: shell
-
-  scp -P XXXXX /local/path/to/file First.Last@localhost:/path/to/file/on/HPCSystems
-
-For Mac or Linux, enter:
-
-.. code-block:: shell
-
-  rsync <put rsync options here> -e 'ssh -l First.Last -p XXXXX' /local/path/to/files First.Last@localhost:/path/to/files/on/HPCSystems
+   $ rsync -e 'ssh -l First.Last -p LOCAL-PORT' \
+     First.Last@localhost:/path/on/hpc/ /local/path/to/files/
 
 .. note::
 
-   Your username is case sensitive when used in the scp command. Username should be in the form of First.Last.
-
-To transfer a file **from** HPC Systems:
-
-For Windows Power Shell, enter:
-
-.. code-block:: shell
-
-    scp -P XXXXX First.Last@localhost:/path/to/file/on/HPCSystems /local/path/to/file
-
-For Mac or Linux, enter:
-
-.. code-block:: shell
-
-    rsync <put rsync options here> -e 'ssh -l First.Last -p XXXXX' First.Last@localhost:/path/to/files/on/HPCSystems /local/path/to/files
-
-
-In either case, you will be asked for a password. Touch your YubiKey for
-authentication.
-
-SSH Port Tunnel For PuTTY Windows Systems
------------------------------------------
-
-PuTTY is an SSH client, used to configure and initiate connection.
-Navigate to a separate tab to install `PuTTY
-<http://www.putty.org/>`_. If you cannot install software on your
-machine, contact your local systems administrator.
-
-**Configuration**
-
-Enter host information to configure an SSH Terminal Session. The
-example below defines a session to Jet via the Boulder Bastion:
-
-.. image:: /images/putty1.png
-   :scale: 75%
-
-1. Enter Username
-In the left pane under Connection, select "Data" and enter your NOAA
-user name as it appears in your NOAA email address. (Ex: Robin.Lee
-if your NOAA email is Robin.Lee@noaa.gov). User name is case
-sensitive - First.Last. If you do not create a username, you will have
-to enter your user name each time your open a session.
-
-.. image:: /images/putty2.png
-   :scale: 75%
-
-Complete the configuration:
-
-* Select "Session" from the top of the left pane.
-* Select "Save" (between Load and Delete).
-
-**Open a First System Session**
-
-Open the session to make sure it's working, and to record your Local
-Port number to complete the Port Tunneling setup.
-
-* Select the configured session from the "Saved Sessions" list. Select
-  Load, then Open.
-* Enter your unique RSA Passcode.
-
-The RSA passcode is your RSA token PIN followed by 8 digits displayed
-on your RSA token. The digits must be on display when you press enter,
-or access will be denied. When you open a new SSH session, wait for
-the RSA token code to refresh before you enter it.
-
-* Find and record your Local Host number.
-
-.. image:: /images/linux_xfer1.png
-    :scale: 75%
-
-* Click **Exit**, or close the Putty window to end the session.
-
-**Port Tunnel Setup**
-
-To enable data transfers, you will need to set up a Port Tunnel.
-
-* Open Putty.
-* Select the session from the Saved Sessions list, then Load.
-* In the left pane under Connection>SSH select Tunnels.
-* Check Local ports accept connections from other hosts.
-* In the Source Port field, enter your Local Port number
-* In the Destination Port field, enter "localhost:<local port
-  number>", where your local port number matches what was entered in
-  the Source port.
-* Select Local and Auto Radio Buttons.
-* Click the Add Button.
-
-.. image:: /images/putty3.png
-
-To save the configuration change:
-
-* In the left pane, select Session.
-* Select Save.
-
-Select **Open** to Login and verify that the updated session works correctly.
-
-Create a new Port Tunnel for each SSH system you intend to use. Each
-one will have a unique Local Port number.
-
-To add extra saved sessions (ex: for another Bastion) for the same
-system (you already have the Local Port number):
-
-* Load your current saved session
-* Enter the new host name for the other Bastion
-* Give the new session a new name (ex: Jet - Princeton)
-* Select Save. The new session will appear in the list of saved sessions.
-* Select Open to Login and verify the new session works correctly.
-
-
-
-SSH Port Tunnel For Tectia Windows Systems
-------------------------------------------
-
-See the :ref:`tectia` pages for complete information.
+   Your username is case sensitive.  Use the ``First.Last`` format.
 
 
 WinSCP
 ------
 
 .. note::
-  You must have a port tunnel established before you can use WinSCP.
-  Configure the port forwarding for WinSCP using the method that
-  matches your system configuration.
 
-.. note::
-  The port-forwarded session must remain
-  active to maintain a connection to WinSCP. Use the word “localhost”
-  where indicated. It is not a variable, don't substitute with anything
-  else.
+   You must establish a port tunnel before using WinSCP.  See
+   :ref:`ssh-port-tunnels` for setup instructions.  The tunnel session
+   must remain open while WinSCP is connected.
 
-Once port forwarding is configured, open and configure WinSCP. Please
-be sure to select SFTP as the file protocol.
+Configure WinSCP with **hostname** ``localhost``, your
+**LocalForward port**, and **file protocol** SFTP.
 
 .. image:: /images/winSCP1.png
   :scale: 50%

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -5,6 +5,20 @@ Glossary
 
 .. glossary::
 
+    bastion host
+        A secure gateway server between your workstation and an RDHPCS
+        compute system.  You authenticate to the bastion first; the
+        bastion then forwards your session to the compute system.
+        See :ref:`connecting-to-rdhpcs`.
+
+    CAC
+        Common Access Card.  A United States Department of Defense smart
+        card used for authentication.  CAC login on RDHPCS systems
+        requires a card reader and the :ref:`Tectia <Tectia>` SSH client.
+
+    Common Access Card
+        See :term:`CAC`.
+
     compute node
         A node type where parallel and threaded applications should be run.
         These nodes typically have large core counts, and a high amount of
@@ -26,5 +40,45 @@ Glossary
         application usage.  This is the node type where users are placed when
         accessing a system.
 
+    master certificate
+        An :term:`X.509` certificate created on your first RDHPCS login.
+        Valid for one year.  Each login derives a short-lived
+        :term:`proxy certificate` from the master certificate to
+        authenticate you to compute systems.
+
+    port forwarding
+        An SSH feature that routes network traffic through an encrypted
+        tunnel between two hosts.  RDHPCS bastions use port forwarding
+        to enable tools such as VS Code Remote-SSH, Jupyter notebooks,
+        and file-transfer utilities.  Also called a port tunnel.
+        See :ref:`ssh-port-tunnels`.
+
+    port tunnel
+        See :term:`port forwarding`.
+
+    proxy certificate
+        A short-lived :term:`X.509` credential derived from your
+        :term:`master certificate`.  Each login renews a 30-day proxy
+        certificate that authenticates you to RDHPCS compute systems
+        and data transfer services.
+
     Slurm
         An open source cluster management and job scheduling system.
+
+    X.509
+        A standard for public-key infrastructure (PKI) digital
+        certificates.  RDHPCS uses X.509 :term:`master certificate`\s
+        and :term:`proxy certificate`\s to authenticate users to
+        compute systems within the enclave.
+
+    X11 forwarding
+        An SSH feature that lets you run graphical applications on a
+        remote system and display their output on your local
+        workstation.  Requires an X11 server on Windows (VcXsrv or
+        MobaXterm) or XQuartz on macOS.  See :ref:`x11-graphics`.
+
+    YubiKey
+        A hardware security key issued by NOAA.  Used with a standard
+        SSH client for two-factor authentication to RDHPCS systems.
+        Requires registration through
+        `Account Information Management <https://aim.rdhpcs.noaa.gov>`__.

--- a/source/index.rst
+++ b/source/index.rst
@@ -89,7 +89,6 @@ Software
    :maxdepth: 2
 
    software/index
-   software/ssh_clients/Tectia/index
 
 
 SLURM

--- a/source/software/VSCode/index.rst
+++ b/source/software/VSCode/index.rst
@@ -31,72 +31,31 @@ Issue the following commands on each remote host:
    mkdir -p /in/your/project/dir/$USER/vscode-server
    ln -s    /in/your/project/dir/$USER/vscode-server ~/.vscode-server
 
-Set up Port Forwarding on your Local client
--------------------------------------------
+Set up a port tunnel
+--------------------
 
-.. note::
-    Each user on the system is assigned a specific Local port number that is
-    different for each host. Your assigned Local port on Hera is
-    different from the one Jet, but will remain fixed.
-
-On your local machine:
-
-1. Get your assigned **Local port number**.
-   If you already know your port number you may skip this step.
-
-2. Login to the appropriate host Hera/Jet/Mercury. In the welcome message look
-   for the following line:
-
-  ``Local port <assigned-port-number> forwarded to remote host``
-
-The number after "Local port" is your assigned port number. Note down this
-number and log out of the system.
-
-Create a session with the tunnel and keep this session open
------------------------------------------------------------
+VSCode Remote-SSH connects to RDHPCS systems through an SSH port
+tunnel.  Set up your tunnel using the instructions in
+:ref:`ssh-port-tunnels`, then keep that session open while you work
+in VSCode.
 
 .. note::
 
-    Windows users please use PowerShell instead of other clients such as putty.
-    Linux users can use the usual ssh command.
-
-Example
-^^^^^^^
-
-This example uses **hera** as our host and **12345** as our assigned
-Local port number, with a username of First.Last.
-
-.. code-block:: console
-
-  ssh                                  -L12345:localhost:12345 First.Last@hera-rsa.boulder.rdhpcs.noaa.gov    (Linux/Mac users)
-  ssh -m hmac-sha2-512-etm@openssh.com -L12345:localhost:12345 First.Last@hera-rsa.boulder.rdhpcs.noaa.gov    (Windows users)
-
-Login, and keep this session open.
-
-Test to make sure the tunnel is working
----------------------------------------
-
-In another local window, type
-
-.. code-block:: console
-
-  ssh -p 12345 First.Last@localhost
-
-
-Enter your PIN+Token at the prompt. If you are successful, your port tunnel is
-all set up and will work long as your session you created is kept
-alive.
+   Windows users must use PowerShell to establish the tunnel, not
+   PuTTY.  PuTTY is not compatible with VSCode Remote-SSH.
 
 Login with your VSCode client
 -----------------------------
 
 .. note::
 
-    We will assume the following:
-    * You have set up the tunnels as mentioned above.
-    * You have installed VSCode on your local machine.
-    * You have  installed the "Remote-SSH" plugin in your VSCode client.
-    * Before you start VSCode, remove any entry containing localhost in your ``~/.ssh/known_hosts`` file
+   Before connecting, confirm that:
+
+   * Your port tunnel is active.  See :ref:`ssh-port-tunnels`.
+   * VSCode is installed on your local machine.
+   * The **Remote-SSH** plugin is installed in VSCode.
+   * Any ``localhost`` entry is removed from your
+     ``~/.ssh/known_hosts`` file.
 
 After you start VSCode, you can select the following menu items:
 
@@ -104,11 +63,13 @@ After you start VSCode, you can select the following menu items:
 
 When prompted for host, enter:
 
-  ``First.Last@localhost:12345``
+  ``First.Last@localhost:LOCAL-PORT``
 
 .. note::
 
-  Remember to replace First.Last with your user name, and to specify your actual Local Port Number.
+   Replace ``First.Last`` with your username and ``LOCAL-PORT`` with
+   your LocalForward port for the system.  See
+   :ref:`ssh-port-tunnels` for port number assignments.
 
 .. note::
 

--- a/source/software/python/jupyter.rst
+++ b/source/software/python/jupyter.rst
@@ -116,11 +116,11 @@ the JupyterLab service you will need to use the pre-established port tunnels.
 There are a few additional steps to access a JupyterLab session that is running
 on the compute nodes.
 
-To access a JupyterLab session on a head node, you will need connect using two
-local terminal sessions.  The first terminal session will establish the
-user-assigned pre-established SSH port tunnels.  The second session will
-establish an additional tunnels to allow the JupyterLab to connect to the
-running JupyterLab port on the head or compute node.
+To access a JupyterLab session on a head node, you need two local
+terminal sessions.  The first session establishes your pre-assigned
+SSH port tunnel (see :ref:`ssh-port-tunnels`).  The second session
+creates an additional tunnel so your browser can reach the JupyterLab
+port on the head or compute node.
 
 .. note::
 
@@ -139,15 +139,10 @@ JupyterLab on Head Nodes
 window 1
 """"""""
 
-Login to the HPC system and establish your tunnel using your assigned user
-local port number:
-
-.. code-block:: shell
-
-    $ ssh -L 12345:127.0.0.1:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
-
-Once logged in, start the JupyterLab session using a port number in the range
-8800-8900 range:
+Establish your SSH port tunnel to the RDHPCS system.  See
+:ref:`ssh-port-tunnels` for setup instructions.  Once logged in,
+start the JupyterLab session using a port number in the 8800–8900
+range:
 
 .. tab-set::
 
@@ -189,11 +184,13 @@ JupyterLab session between your localhost and the RDHPCS system:
 
 .. code-block:: shell
 
-    $ ssh -p 12345 -L <port#>:127.0.0.1:<port#> J.Doe@127.0.0.1
+    $ ssh -p LOCAL-PORT -L <port#>:127.0.0.1:<port#> First.Last@127.0.0.1
 
 .. note::
 
-    This will not give you a prompt on the RDHPCS system.
+    Replace ``LOCAL-PORT`` with your LocalForward port for the system.
+    See :ref:`ssh-port-tunnels` for port number assignments.
+    This command does not give you a shell prompt on the RDHPCS system.
 
 Open your browser on your local machine, and navigate to the entire URL
 (including the token) you noted above when you ran ``jupyter lab`` in window 1
@@ -204,12 +201,8 @@ JupyterLab on Compute Nodes
 window 1
 """"""""
 
-Login to the HPC system and establish your tunnel using your assigned user
-local port number:
-
-.. code-block:: shell
-
-    $ ssh -L 12345:127.0.0.1:12345 J.Doe@<bastion>.rdhpcs.noaa.gov
+Establish your SSH port tunnel to the RDHPCS system.  See
+:ref:`ssh-port-tunnels` for setup instructions.
 
 Start an interactive batch session.  On the compute node, use ``hostname`` to
 get the name of the compute node.  This will be needed later:
@@ -264,10 +257,10 @@ JupyterLab session between your localhost and the RDHPCS system:
 
 .. code-block:: shell
 
-    $ ssh -p 12345 -L <port#>:127.0.0.1:<port#> J.Doe@127.0.0.1
+    $ ssh -p LOCAL-PORT -L <port#>:127.0.0.1:<port#> First.Last@127.0.0.1
 
-Once the connection is established, using the compute node host name establish
-a connection to the compute node with tunnels to the JupyterLab session port:
+Once the connection is established, use the compute node hostname to
+connect to the compute node and tunnel the JupyterLab session port:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Closes #130

## Summary

- **Restructure SSH client docs**: Move all SSH client pages from `source/software/ssh_clients/` to `source/connecting/ssh_clients/` so they live alongside the connecting guide. Create new pages for OpenSSH and PuTTY; expand the existing Tectia page.
- **New SSH client hub page** (`connecting/ssh_clients/index.rst`): Client selection table by platform and auth method; post-install guidance; toctree for all three clients.
- **Per-client pages** now cover install, configure for RDHPCS, X11 forwarding, and port tunnel setup with screenshots where applicable, plus links to official docs/man pages.
- **Migrate steps from `connecting/index.rst`**: Per-client tunnel and X11 steps removed from the canonical page; replaced with cross-references to the client pages. Port assignment table, formula, config form reference, verify steps, and warning block remain canonical.
- **Fill content gaps** identified in consolidation review:
  - Windows HMAC MAC algorithm flag (`-m hmac-sha2-512-etm@openssh.com`)
  - Login banner as port number discovery method
  - YubiKey MFA test note on tunnel verification
  - Combined `-X -L` usage for X11 + port tunnel in one session
  - Promote session-open reminder to `.. warning::` block
- **Glossary additions**: bastion host, CAC, Common Access Card, port forwarding, port tunnel, proxy certificate, master certificate, X.509, X11 forwarding, YubiKey.

## Test plan

- [ ] `sphinx-build` produces zero warnings and zero errors
- [ ] `connecting/index.rst` renders correctly with cross-references to client pages resolving
- [ ] All three client pages (OpenSSH, PuTTY, Tectia) appear in the left navigation under Connecting → SSH Clients
- [ ] Glossary page renders all new terms with working cross-references
- [ ] Verify screenshots render on PuTTY and Tectia pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)