### PR TITLE
Improve Makefile and make.bat build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,76 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line, and also
-# from the environment for the first two.
+# You can set these variables from the command line or environment.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
-LINTRST       ?= doc8
+PORT          ?= 8000
+VENV          = .venv
+PYTHON        = $(VENV)/bin/python
+PIP           = $(VENV)/bin/pip
+MIN_PY_VER    = 3.10
+
+# Verify python3 is available and meets minimum version requirement.
+PYTHON3 := $(shell command -v python3 2>/dev/null)
+ifeq ($(PYTHON3),)
+  $(error python3 not found. Please install Python $(MIN_PY_VER) or newer.)
+endif
+PYTHON3_VER := $(shell python3 -c \
+  "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+PYTHON3_OK := $(shell python3 -c \
+  "import sys; print('ok' if sys.version_info >= (3,10) else 'old')")
+ifneq ($(PYTHON3_OK),ok)
+  $(error Python $(MIN_PY_VER)+ required, found $(PYTHON3_VER). Please upgrade Python.)
+endif
+
+# Use venv binaries so the user does not need to activate the environment.
+SPHINXBUILD   := $(VENV)/bin/sphinx-build
+LINTRST       := $(VENV)/bin/doc8
 
 # Put it first so that "make" without argument is like "make help".
-help:
+help: venv
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo "  lint        to run a linter on the RST files in the source directory"
+	@echo "  serve       to start a local web server on port $(PORT) to view the built docs"
+	@echo "  venv        to create the Python virtual environment and install dependencies"
+	@echo "  distclean   to remove the build directory and the virtual environment"
 
-.PHONY: help Makefile
+.PHONY: help Makefile lint serve venv distclean
 
-lint: Makefile
+# Prevent the catch-all pattern rule from trying to "build" requirements.txt.
+requirements.txt: ;
+
+# Create the virtual environment and install dependencies.
+venv: $(VENV)/bin/activate
+
+$(VENV)/bin/activate: requirements.txt
+	@echo "Creating Python virtual environment in $(VENV)/ ..."
+	@python3 -m venv $(VENV)
+	@echo "Installing dependencies from requirements.txt ..."
+	@$(PIP) install --quiet --upgrade pip
+	@$(PIP) install --quiet -r requirements.txt
+	@touch $(VENV)/bin/activate
+	@echo "Virtual environment ready."
+
+distclean:
+	@echo "Removing build directory $(BUILDDIR)/ ..."
+	@rm -rf $(BUILDDIR)
+	@echo "Removing virtual environment $(VENV)/ ..."
+	@rm -rf $(VENV)
+
+serve: html
+	@if lsof -ti:$(PORT) >/dev/null 2>&1; then \
+		echo "Error: Port $(PORT) is already in use. Run 'make serve PORT=<number>' to use a different port."; \
+		exit 1; \
+	fi
+	@echo "Serving documentation at http://localhost:$(PORT) (press Ctrl+C to stop)"
+	@$(PYTHON) -m http.server $(PORT) --directory "$(BUILDDIR)/html"
+
+lint: venv
 	@$(LINTRST) $(SOURCEDIR)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: venv Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-

--- a/make.bat
+++ b/make.bat
@@ -4,32 +4,75 @@ pushd %~dp0
 
 REM Command file for Sphinx documentation
 
-if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
-)
-set SOURCEDIR=source
-set BUILDDIR=build
+SET SOURCEDIR=source
+SET BUILDDIR=build
+SET VENV=.venv
+SET SPHINXBUILD=%VENV%\Scripts\sphinx-build
+SET LINTRST=%VENV%\Scripts\doc8
+SET PYTHON=%VENV%\Scripts\python
+SET PIP=%VENV%\Scripts\pip
+SET MIN_PY_VER=3.10
+SET PORT=8000
 
-%SPHINXBUILD% >NUL 2>NUL
-if errorlevel 9009 (
+REM Verify python3 is available and meets minimum version requirement.
+python --version >NUL 2>NUL
+if errorlevel 1 (
 	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.https://www.sphinx-doc.org/
+	echo.Python not found. Please install Python %MIN_PY_VER% or newer.
 	exit /b 1
 )
 
+for /f "tokens=*" %%V in ('python -c "import sys; print('ok' if sys.version_info >= (3,10) else 'old')"') do set PYTHON3_OK=%%V
+if "%PYTHON3_OK%" == "old" (
+	for /f "tokens=*" %%V in ('python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"') do set PYTHON3_VER=%%V
+	echo.
+	echo.Python %MIN_PY_VER%+ required, found %PYTHON3_VER%. Please upgrade Python.
+	exit /b 1
+)
+
+REM Create the virtual environment and install dependencies if needed.
+if not exist "%VENV%\Scripts\activate" (
+	echo Creating Python virtual environment in %VENV%\ ...
+	python -m venv %VENV%
+	echo Installing dependencies from requirements.txt ...
+	%PIP% install --quiet --upgrade pip
+	%PIP% install --quiet -r requirements.txt
+	echo Virtual environment ready.
+)
+
 if "%1" == "" goto help
+if "%1" == "distclean" goto distclean
+if "%1" == "lint" goto lint
+if "%1" == "serve" goto serve
+if "%1" == "venv" goto end
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+echo.  lint        to run a linter on the RST files in the source directory
+echo.  serve       to start a local web server on port %PORT% to view the built docs
+echo.  venv        to create the Python virtual environment and install dependencies
+echo.  distclean   to remove the build directory and the virtual environment
+goto end
+
+:lint
+%LINTRST% %SOURCEDIR%
+goto end
+
+:serve
+%SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+echo Serving documentation at http://localhost:%PORT% (press Ctrl+C to stop)
+%PYTHON% -m http.server %PORT% --directory "%BUILDDIR%\html"
+goto end
+
+:distclean
+echo Removing build directory %BUILDDIR%\ ...
+if exist "%BUILDDIR%" rmdir /s /q %BUILDDIR%
+echo Removing virtual environment %VENV%\ ...
+if exist "%VENV%" rmdir /s /q %VENV%
+goto end
 
 :end
 popd


### PR DESCRIPTION
## Summary

- Auto-create and manage `.venv` using a sentinel file; users no longer need to manually activate the environment before building
- Use explicit `.venv/bin/` paths for `sphinx-build` and `doc8` (consistent with `AGENTS.md` guidance)
- Add `serve` target with port-in-use detection (configurable via `PORT=`)
- Add `distclean` target to remove both `build/` and `.venv/`
- Add Python 3.10+ version check with a clear error on older versions
- Sync `make.bat` to match `Makefile` behavior, including explicit `venv` command handling to prevent fallthrough to `sphinx-build`
- Remove unnecessary `Makefile` prerequisite from the `lint` target (only needed in the catch-all pattern rule)

Closes #739

## Test plan

- [ ] `make` — shows help without error
- [ ] `make html` — creates `.venv/`, installs deps, builds HTML
- [ ] `make lint` — runs `doc8` against `source/`
- [ ] `make serve` — serves built docs; re-running on same port prints error
- [ ] `make distclean` — removes `build/` and `.venv/`
- [ ] `make.bat venv` — sets up environment without calling sphinx-build

🤖 Generated with [Claude Code](https://claude.com/claude-code)