### PR TITLE
Update PPAN conda module load command in doc

### DIFF
--- a/source/software/python/conda_basics.rst
+++ b/source/software/python/conda_basics.rst
@@ -76,7 +76,7 @@ packages assume use of GCC.
 
         .. code-block:: bash
 
-            $ module load rdhpc-conda
+            $ module load conda
 
 
 This puts you in the "base" conda environment( and activates it), which is


### PR DESCRIPTION
I was trying to work with conda on ppan, and I noticed that the doc's module (`rdhpc-conda`) didn't work for me, but `module load conda` seemed okay.


```
an014:~/work/20260716_mdtf> module load rdhpc-conda
Lmod has detected the following error:  The following module(s) are unknown: "rdhpc-conda"

Please check the spelling or version number. Also try "module spider ..."
It is also possible your cache file is out-of-date; it may help to try:
  $ module --ignore_cache load "rdhpc-conda"

Also make sure that all modulefiles written in TCL start with the string #%Module

an014:~/work/20260716_mdtf> module load conda
an014:~/work/20260716_mdtf>
```