### PR TITLE
changed python load command

### DIFF
--- a/source/connecting/index.rst
+++ b/source/connecting/index.rst
@@ -339,3 +339,4 @@ Web based ParallelWorks Access
 
 See the :ref:`cloud-user-guide` for details on using ParallelWorks in
 a web browser to access on-premise and cloud HPCS.
+

--- a/source/software/python/conda_basics.rst
+++ b/source/software/python/conda_basics.rst
@@ -76,7 +76,7 @@ packages assume use of GCC.
 
         .. code-block:: bash
 
-            $ module load rdhpc-conda
+            $ module load conda
 
 
 This puts you in the "base" conda environment( and activates it), which is

--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -148,7 +148,7 @@ To start using Python, load the ``python`` module.
 
         .. code-block:: bash
 
-            $ module load rdhpcs-python
+            $ module load python
 
     .. tab-item:: Orion
         :sync: orion

--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -148,7 +148,7 @@ To start using Python, load the ``python`` module.
 
         .. code-block:: bash
 
-            $ module load python
+            $ module load rdhpcs-python
 
     .. tab-item:: Orion
         :sync: orion


### PR DESCRIPTION
Janice Kim discovered an error in the Python docs. I updated the command syntax to what worked.  (See closed PR 

Janice wrote: 

I was trying to work with conda on ppan, and I noticed that the doc's module (rdhpc-conda) didn't work for me, but module load conda seemed okay.

_an014:~/work/20260716_mdtf> module load rdhpc-conda
Lmod has detected the following error: The following module(s) are unknown: "rdhpc-conda"

Please check the spelling or version number. Also try "module spider ..."
It is also possible your cache file is out-of-date; it may help to try:
$ module --ignore_cache load "rdhpc-conda"

Also make sure that all modulefiles written in TCL start with the string #%Module

an014:/work/20260716_mdtf> module load conda
an014:/work/20260716_mdtf>_