### PR TITLE
Large Conda environment fix

### DIFF
--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -499,11 +499,10 @@ Cloning the base environment using conda
 It is not recommended to install new packages into the base environment.
 Instead, you should clone the base environment and install packages into the
 clone. To clone an environment, use the ``--clone <env_to_clone>`` flag when
-creating a new conda environment. Note for a very large environment we recommend
-the user to install their own miniforge environment in project space 
-Below is an example of cloning the base
-environment into a specific directory called ``envs/baseClone`` in your
-"Project Home":
+creating a new conda environment. Note for a very large environment we
+recommend the user to install their own miniforge environment in project
+space. Below is an example of cloning the base environment into a specific
+directory called ``envs/baseClone`` in your "Project Home":
 
 .. code-block:: bash
 

--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -500,7 +500,7 @@ It is not recommended to install new packages into the base environment.
 Instead, you should clone the base environment and install packages into the
 clone. To clone an environment, use the ``--clone <env_to_clone>`` flag when
 creating a new conda environment. Note for a very large environment we
-recommend the user to install their own miniforge environment in project
+recommend that the user install their own miniforge environment in project
 space. Below is an example of cloning the base environment into a specific
 directory called ``envs/baseClone`` in your "Project Home":
 

--- a/source/software/python/index.rst
+++ b/source/software/python/index.rst
@@ -49,14 +49,6 @@ transcript of the presentation.
     Academia and Research
     <https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research>`_.
 
-.. note::
-
-    The only conda channel approved for use on the NOAA RDHPCS systems is
-    `conda-forge <https://conda-forge.org>`_.  The conda-forge installer,
-    `Miniforge <https://conda-forge.org/download/>`_, includes the `conda`_
-    package manager and will use the `conda-forge`_ channel. This is the
-    default channel for Miniforge3 but not for anaconda.
-
 If you want to leverage Python with Jupyter, we direct you to our
 :ref:`jupyter_on_rdhpcs_systems` page for comprehensive guidance.
 
@@ -507,7 +499,9 @@ Cloning the base environment using conda
 It is not recommended to install new packages into the base environment.
 Instead, you should clone the base environment and install packages into the
 clone. To clone an environment, use the ``--clone <env_to_clone>`` flag when
-creating a new conda environment. Below is an example of cloning the base
+creating a new conda environment. Note for a very large environment we recommend
+the user to install their own miniforge environment in project space 
+Below is an example of cloning the base
 environment into a specific directory called ``envs/baseClone`` in your
 "Project Home":
 

--- a/source/software/python/miniforge.rst
+++ b/source/software/python/miniforge.rst
@@ -12,17 +12,19 @@ Installing Miniforge
 ********************
 
 While the RDHPCS system have Miniforge available, you can install your own
-`Miniforge <https://docs.conda.io/en/main/miniconda.html>`__.
+`Miniforge <https://docs.conda.io/en/main/miniconda.html>`__. The main
+reason for doing this is if your environemnt you wish to create is far
+larger than your home directory.
 
 The install process is rather simple (with a few notable warnings, see
 :ref:`Cautionary Notes <miniforge-notes>` further below):
 
 .. code-block:: bash
 
-   $ mkdir miniforge
-   $ cd miniforge/
+   $ mkdir some_project_space_directory/miniforge
+   $ cd some_project_space_directoy/miniforge/
    wget https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Linux-x86_64.sh
-   sh Miniforge3-25.3.0-3-Linux-x86_64.sh -u -p ~/miniforge
+   sh Miniforge3-25.3.0-3-Linux-x86_64.sh -u -p some_project_space_directory/miniforge
 
 * The ``-p`` flag specifies the prefix path for where to install miniforge.
 * The ``-u`` updates any current installations at the ``-p`` location (not

--- a/source/software/python/miniforge.rst
+++ b/source/software/python/miniforge.rst
@@ -22,7 +22,7 @@ The install process is rather simple (with a few notable warnings, see
 .. code-block:: bash
 
    $ mkdir some_project_space_directory/miniforge
-   $ cd some_project_space_directoy/miniforge/
+   $ cd some_project_space_directoy/miniforge
    wget https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Linux-x86_64.sh
    sh Miniforge3-25.3.0-3-Linux-x86_64.sh -u -p some_project_space_directory/miniforge
 


### PR DESCRIPTION
Change conda documentation to include the case where the environment  to be created is very large. 
See issue https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io/issues/813